### PR TITLE
Remove Team Member

### DIFF
--- a/src/TeamUp.Application/Teams/RemoveTeamMember/RemoveTeamMemberCommand.cs
+++ b/src/TeamUp.Application/Teams/RemoveTeamMember/RemoveTeamMemberCommand.cs
@@ -1,0 +1,8 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Application.Teams.RemoveTeamMember;
+
+public sealed record RemoveTeamMemberCommand(UserId InitiatorId, TeamId TeamId, TeamMemberId MemberId) : ICommand<Result>;

--- a/src/TeamUp.Application/Teams/RemoveTeamMember/RemoveTeamMemberCommandHandler.cs
+++ b/src/TeamUp.Application/Teams/RemoveTeamMember/RemoveTeamMemberCommandHandler.cs
@@ -1,0 +1,27 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Teams;
+
+namespace TeamUp.Application.Teams.RemoveTeamMember;
+
+internal sealed class RemoveTeamMemberCommandHandler : ICommandHandler<RemoveTeamMemberCommand, Result>
+{
+	private readonly ITeamRepository _teamRepository;
+	private readonly IUnitOfWork _unitOfWork;
+
+	public RemoveTeamMemberCommandHandler(ITeamRepository teamRepository, IUnitOfWork unitOfWork)
+	{
+		_teamRepository = teamRepository;
+		_unitOfWork = unitOfWork;
+	}
+
+	public async Task<Result> Handle(RemoveTeamMemberCommand request, CancellationToken ct)
+	{
+		var team = await _teamRepository.GetTeamByIdAsync(request.TeamId, ct);
+		return await team
+			.EnsureNotNull(TeamErrors.TeamNotFound)
+			.Then(team => team.RemoveTeamMember(request.InitiatorId, request.MemberId))
+			.TapAsync(() => _unitOfWork.SaveChangesAsync(ct));
+	}
+}

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.Tap.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.Tap.cs
@@ -11,6 +11,15 @@ public static partial class ResultExtensions
 		return self;
 	}
 
+	public static async Task<Result> TapAsync(this Result self, Func<Task> asyncFunc)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		await asyncFunc();
+		return Result.Success;
+	}
+
 	public static async Task<Result<TValue>> TapAsync<TValue>(this Result<TValue> self, Func<TValue, Task> asyncFunc)
 	{
 		if (self.IsFailure)

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.Then.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.Then.cs
@@ -10,6 +10,14 @@ public static partial class ResultExtensions
 		return mapper(self.Value!);
 	}
 
+	public static Result Then<TValue>(this Result<TValue> self, Func<TValue, Result> mapper)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		return mapper(self.Value!);
+	}
+
 	public static Result<TOut> Then<TValue, TOut>(this Result<TValue> self, Func<TValue, Result<TOut>> mapper)
 	{
 		if (self.IsFailure)

--- a/src/TeamUp.Domain/Aggregates/Teams/TeamMember.cs
+++ b/src/TeamUp.Domain/Aggregates/Teams/TeamMember.cs
@@ -36,6 +36,8 @@ public sealed class TeamMember : Entity<TeamMemberId>
 		TimeStamp = timeStamp;
 	}
 
+	public override string ToString() => $"{Nickname} ({Role})";
+
 	internal void UpdateNickname(string nickname)
 	{
 		Nickname = nickname;

--- a/src/TeamUp.Domain/Aggregates/Teams/TeamRules.cs
+++ b/src/TeamUp.Domain/Aggregates/Teams/TeamRules.cs
@@ -25,7 +25,7 @@ public static class TeamRules
 	public static readonly RuleWithError<TeamMember> MemberCanChangeTeamName = new(MemberIsOwner, TeamErrors.UnauthorizedToChangeTeamName);
 
 	public static readonly RuleWithError<(TeamMember Member, TeamMember Initiator)> MemberCanBeRemovedByInitiator = new(
-		context => context.Member.Role.CanRemoveTeamMembers() || context.Initiator.Id == context.Member.Id,
+		context => context.Initiator.Role.CanRemoveTeamMembers() || context.Initiator.Id == context.Member.Id,
 		TeamErrors.UnauthorizedToRemoveTeamMembers
 	);
 }

--- a/src/TeamUp.Domain/Aggregates/Users/User.cs
+++ b/src/TeamUp.Domain/Aggregates/Users/User.cs
@@ -28,6 +28,8 @@ public sealed class User : AggregateRoot<User, UserId>
 		AddDomainEvent(new UserCreatedDomainEvent(this));
 	}
 
+	public override string ToString() => Name;
+
 	public void Activate()
 	{
 		Status = UserStatus.Activated;

--- a/tests/TeamUp.EndToEndTests/EndpointTests/BaseEndpointTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/BaseEndpointTests.cs
@@ -50,16 +50,6 @@ public abstract class BaseEndpointTests : IAsyncLifetime
 		Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
 	}
 
-	protected async ValueTask UseDbContextAsync(Func<ApplicationDbContext, ValueTask> apply)
-	{
-		await using var scope = AppFactory.Services.CreateAsyncScope();
-
-		await using var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-		await apply(dbContext);
-
-		await scope.DisposeAsync();
-	}
-
 	protected async Task UseDbContextAsync(Func<ApplicationDbContext, Task> apply)
 	{
 		await using var scope = AppFactory.Services.CreateAsyncScope();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/TeamMemberTests.Remove.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/TeamMemberTests.Remove.cs
@@ -1,0 +1,283 @@
+﻿namespace TeamUp.EndToEndTests.EndpointTests.Teams;
+
+public sealed partial class TeamMemberTests : BaseEndpointTests
+{
+	public TeamMemberTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+
+	[Theory]
+	[InlineData(TeamRole.Member)]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	public async Task RemoveTeamMember_AsOwner_WhenRemovingAdminOrLower_Should_RemoveTeamMemberFromTeam(TeamRole targetMemberRole)
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(18);
+		var team = TeamGenerator.GenerateTeamWith(owner, members, (targetUser, targetMemberRole));
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == targetUser.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(owner);
+			dbContext.Users.Add(targetUser);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(owner);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be200Ok();
+
+		await UseDbContextAsync(async dbContext =>
+		{
+			var targetMember = await dbContext.Set<TeamMember>().FindAsync(targetMemberId);
+			targetMember.Should().BeNull("this member has been removed");
+
+			var targetMemberUser = await dbContext.Users.FindAsync(targetUser.Id);
+			targetMemberUser.ShouldNotBeNull();
+			targetMemberUser.Should().BeEquivalentTo(targetUser);
+		});
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Member)]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	public async Task RemoveTeamMember_AsAdmin_WhenRemovingAdminOrLower_Should_RemoveTeamMemberFromTeam(TeamRole targetMemberRole)
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(18);
+		var team = TeamGenerator.GenerateTeamWith(owner, members, (initiatorUser, TeamRole.Admin), (targetUser, targetMemberRole));
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == targetUser.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be200Ok();
+
+		await UseDbContextAsync(async dbContext =>
+		{
+			var targetMember = await dbContext.Set<TeamMember>().FindAsync(targetMemberId);
+			targetMember.Should().BeNull("this member has been removed");
+
+			var targetMemberUser = await dbContext.Users.FindAsync(targetUser.Id);
+			targetMemberUser.ShouldNotBeNull();
+			targetMemberUser.Should().BeEquivalentTo(targetUser);
+		});
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Member)]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	public async Task RemoveTeamMember_AsAdminOrLower_WhenRemovingMyself_Should_RemoveTeamMemberFromTeam(TeamRole memberRole)
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var user = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(18);
+		var team = TeamGenerator.GenerateTeamWith(owner, members, (user, memberRole));
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == user.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, user]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(user);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be200Ok();
+
+		await UseDbContextAsync(async dbContext =>
+		{
+			var targetMember = await dbContext.Set<TeamMember>().FindAsync(targetMemberId);
+			targetMember.Should().BeNull("this member has been removed");
+
+			var targetMemberUser = await dbContext.Users.FindAsync(user.Id);
+			targetMemberUser.ShouldNotBeNull();
+			targetMemberUser.Should().BeEquivalentTo(user);
+		});
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Member)]
+	[InlineData(TeamRole.Coordinator)]
+	public async Task RemoveTeamMember_AsCoordinatorOrMember_WhenRemovingTeamMember_Should_ResultInForbidden(TeamRole memberRole)
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(18);
+		var team = TeamGenerator.GenerateTeamWith(owner, members, (initiatorUser, memberRole), (targetUser, TeamRole.Member));
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == targetUser.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be403Forbidden();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.UnauthorizedToRemoveTeamMembers);
+	}
+
+	[Fact]
+	public async Task RemoveTeamMember_AsOwner_WhenRemovingMyself_Should_ResultInDomainError_BadRequest()
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(owner, members);
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == owner.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(owner);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(owner);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be400BadRequest();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.CannotRemoveTeamOwner);
+	}
+
+	[Fact]
+	public async Task RemoveTeamMember_AsAdmin_WhenRemovingTeamOwner_Should_ResultInDomainError_BadRequest()
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var user = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(18);
+		var team = TeamGenerator.GenerateTeamWith(owner, members, (user, TeamRole.Admin));
+
+		var targetMemberId = team.Members.FirstOrDefault(member => member.UserId == owner.Id)!.Id;
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, user]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(owner);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+
+		//assert
+		response.Should().Be400BadRequest();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.CannotRemoveTeamOwner);
+	}
+
+	[Fact]
+	public async Task RemoveTeamMember_ThatDoesNotExist_AsOwner_Should_ResultInNotFound()
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(owner, members);
+
+		var targetMemberId = F.Random.Guid();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(owner);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(owner);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId}");
+
+		//assert
+		response.Should().Be404NotFound();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.MemberNotFound);
+	}
+
+	[Fact]
+	public async Task RemoveTeamMember_FromTeamThaDoesNotExist_Should_ResultInNotFound()
+	{
+		//arrange
+		var user = UserGenerator.ActivatedUser.Generate();
+
+		var teamId = F.Random.Guid();
+		var targetMemberId = F.Random.Guid();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(user);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(user);
+
+		//act
+		var response = await Client.DeleteAsync($"/api/v1/teams/{teamId}/{targetMemberId}");
+
+		//assert
+		response.Should().Be404NotFound();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.TeamNotFound);
+	}
+}

--- a/tests/TeamUp.EndToEndTests/Extensions/ServiceCollectionExtensions.cs
+++ b/tests/TeamUp.EndToEndTests/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection.Extensions;
-
-namespace TeamUp.EndToEndTests.Extensions;
+﻿namespace TeamUp.EndToEndTests.Extensions;
 
 public static class ServiceCollectionExtensions
 {

--- a/tests/TeamUp.TestsCommon/FakerExtensions.cs
+++ b/tests/TeamUp.TestsCommon/FakerExtensions.cs
@@ -23,5 +23,16 @@ public static class FakerExtensions
 		return faker.RuleFor(backingField, _ => value);
 	}
 
+	public static Faker<T> RuleForBackingField<T, TProperty>(this Faker<T> faker, Expression<Func<T, TProperty>> property, Func<Faker, TProperty> setter) where T : class
+	{
+		if (property.Body is not MemberExpression memberExpression || memberExpression.Member is not PropertyInfo propertyInfo)
+		{
+			throw new ArgumentException("Expression must be a MemberExpression pointing to a PropertyInfo", nameof(property));
+		}
+
+		var backingField = propertyInfo.Name.GetBackingField();
+		return faker.RuleFor(backingField, setter);
+	}
+
 	public static string GetBackingField(this string propertyName) => $"<{propertyName}>k__BackingField";
 }


### PR DESCRIPTION
- added remove team member endpoint, command, command handler
- added needed extension methods for result pattern (Then, TapAsync)
- added tests for remove team member
- fixed related bug (wrong validation member rights)
- added needed extension faker method
- restructurized endpoint tests (split tests into more files, added sub-directories)
- added ToString override for some objects for easier debugging