### PR TITLE
Invite User To Team + Get Team Invitations

### DIFF
--- a/src/TeamUp.Api/Endpoints/Invitations/GetTeamInvitationsEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/GetTeamInvitationsEndpoint.cs
@@ -1,0 +1,35 @@
+﻿using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using TeamUp.Api.Extensions;
+using TeamUp.Application.Invitations.GetTeamInvitations;
+using TeamUp.Contracts.Invitations;
+using TeamUp.Domain.Aggregates.Teams;
+
+namespace TeamUp.Api.Endpoints.Invitations;
+
+public sealed class GetTeamInvitationsEndpoint : IEndpointGroup
+{
+	public void MapEndpoints(RouteGroupBuilder group)
+	{
+		group.MapGet("/teams/{teamId:guid}", GetTeamInvitationsAsync)
+			.Produces<List<TeamInvitationResponse>>(StatusCodes.Status200OK)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
+			.WithName(nameof(GetTeamInvitationsEndpoint))
+			.MapToApiVersion(1);
+	}
+
+	private async Task<IResult> GetTeamInvitationsAsync(
+		[FromRoute] Guid teamId,
+		[FromServices] ISender sender,
+		[FromServices] IHttpContextAccessor httpContextAccessor,
+		CancellationToken ct)
+	{
+		var query = new GetTeamInvitationsQuery(httpContextAccessor.GetLoggedUserId(), TeamId.FromGuid(teamId));
+		var result = await sender.Send(query, ct);
+		return result.Match(TypedResults.Ok);
+	}
+}

--- a/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using TeamUp.Api.Extensions;
+using TeamUp.Application.Invitations.InviteUser;
+using TeamUp.Contracts.Invitations;
+using TeamUp.Domain.Aggregates.Invitations;
+
+namespace TeamUp.Api.Endpoints.Invitations;
+
+public sealed class InviteUserEndpoint : IEndpointGroup
+{
+	public void MapEndpoints(RouteGroupBuilder group)
+	{
+		group.MapPost("/", InviteUserAsync)
+			.Produces<InvitationId>(StatusCodes.Status201Created)
+			.Produces(StatusCodes.Status401Unauthorized)
+			.Produces(StatusCodes.Status403Forbidden)
+			.Produces(StatusCodes.Status404NotFound)
+			.ProducesValidationProblem()
+			.MapToApiVersion(1)
+			.WithName(nameof(InviteUserEndpoint));
+	}
+
+	private async Task<IResult> InviteUserAsync(
+		[FromBody] InviteUserRequest request,
+		[FromServices] ISender sender,
+		[FromServices] IHttpContextAccessor httpContextAccessor,
+		[FromServices] LinkGenerator linkGenerator,
+		CancellationToken ct)
+	{
+		var command = new InviteUserCommand(httpContextAccessor.GetLoggedUserId(), request.TeamId, request.Email);
+
+		var result = await sender.Send(command, ct);
+		return result.Match(invitationId => TypedResults.Created(
+			uri: linkGenerator.GetPathByName(nameof(GetTeamInvitationsEndpoint), request.TeamId.Value),
+			value: invitationId
+		));
+	}
+}

--- a/src/TeamUp.Api/Endpoints/InvitationsEndpointGroup.cs
+++ b/src/TeamUp.Api/Endpoints/InvitationsEndpointGroup.cs
@@ -1,0 +1,14 @@
+﻿using TeamUp.Api.Endpoints.Invitations;
+using TeamUp.Api.Extensions;
+
+namespace TeamUp.Api.Endpoints;
+
+public sealed class InvitationsEndpointGroup : IEndpointGroup
+{
+	public void MapEndpoints(RouteGroupBuilder group)
+	{
+		group.RequireAuthorization()
+			.MapEndpoint<InviteUserEndpoint>()
+			.MapEndpoint<GetTeamInvitationsEndpoint>();
+	}
+}

--- a/src/TeamUp.Api/Endpoints/Teams/ChangeOwnerShipEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/ChangeOwnerShipEndpoint.cs
@@ -8,7 +8,7 @@ using TeamUp.Domain.Aggregates.Teams;
 
 namespace TeamUp.Api.Endpoints.Teams;
 
-public class ChangeOwnerShipEndpoint : IEndpointGroup
+public class ChangeOwnershipEndpoint : IEndpointGroup
 {
 	public void MapEndpoints(RouteGroupBuilder group)
 	{
@@ -17,7 +17,7 @@ public class ChangeOwnerShipEndpoint : IEndpointGroup
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
-			.WithName(nameof(ChangeOwnerShipEndpoint))
+			.WithName(nameof(ChangeOwnershipEndpoint))
 			.MapToApiVersion(1);
 	}
 

--- a/src/TeamUp.Api/Endpoints/Teams/CreateTeamEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/CreateTeamEndpoint.cs
@@ -30,7 +30,7 @@ public sealed class CreateTeamEndpoint : IEndpointGroup
 		var command = new CreateTeamCommand(httpContextAccessor.GetLoggedUserId(), request.Name);
 		var result = await sender.Send(command, ct);
 		return result.Match(teamId => TypedResults.Created(
-			uri: linkGenerator.GetPathByName(nameof(GetTeamEndpoint)),
+			uri: linkGenerator.GetPathByName(nameof(GetTeamEndpoint), teamId.Value),
 			value: teamId
 		));
 	}

--- a/src/TeamUp.Api/Endpoints/TeamsEndpointGroup.cs
+++ b/src/TeamUp.Api/Endpoints/TeamsEndpointGroup.cs
@@ -3,7 +3,7 @@ using TeamUp.Api.Extensions;
 
 namespace TeamUp.Api.Endpoints;
 
-public sealed class TeamEndpointGroup : IEndpointGroup
+public sealed class TeamsEndpointGroup : IEndpointGroup
 {
 	public void MapEndpoints(RouteGroupBuilder group)
 	{
@@ -11,7 +11,7 @@ public sealed class TeamEndpointGroup : IEndpointGroup
 			.MapEndpoint<CreateTeamEndpoint>()
 			.MapEndpoint<GetTeamEndpoint>()
 			.MapEndpoint<DeleteTeamEndpoint>()
-			.MapEndpoint<ChangeOwnerShipEndpoint>()
+			.MapEndpoint<ChangeOwnershipEndpoint>()
 			.MapEndpoint<RemoveTeamMemberEndpoint>()
 			.MapEndpoint<UpdateTeamMemberRoleEndpoint>()
 			.MapEndpoint<UpdateTeamNameEndpoint>()

--- a/src/TeamUp.Api/Extensions/WebApplicationExtensions.cs
+++ b/src/TeamUp.Api/Extensions/WebApplicationExtensions.cs
@@ -26,7 +26,8 @@ public static class WebApplicationExtensions
 
 		apiGroup
 			.MapEndpointGroup<UserAccessEndpointGroup>("users")
-			.MapEndpointGroup<TeamEndpointGroup>("teams");
+			.MapEndpointGroup<TeamsEndpointGroup>("teams")
+			.MapEndpointGroup<InvitationsEndpointGroup>("invitations");
 	}
 
 	public static async Task ApplyMigrationsAsync(this WebApplication app, CancellationToken ct = default)

--- a/src/TeamUp.Application/Invitations/GetTeamInvitations/GetTeamInvitationsQuery.cs
+++ b/src/TeamUp.Application/Invitations/GetTeamInvitations/GetTeamInvitationsQuery.cs
@@ -1,0 +1,9 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Contracts.Invitations;
+using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Application.Invitations.GetTeamInvitations;
+
+public sealed record GetTeamInvitationsQuery(UserId InitiatorId, TeamId TeamId) : IQuery<Result<List<TeamInvitationResponse>>>;

--- a/src/TeamUp.Application/Invitations/GetTeamInvitations/GetTeamInvitationsQueryHandler.cs
+++ b/src/TeamUp.Application/Invitations/GetTeamInvitations/GetTeamInvitationsQueryHandler.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Contracts.Invitations;
+using TeamUp.Domain.Aggregates.Teams;
+
+namespace TeamUp.Application.Invitations.GetTeamInvitations;
+
+internal sealed class GetTeamInvitationsQueryHandler : IQueryHandler<GetTeamInvitationsQuery, Result<List<TeamInvitationResponse>>>
+{
+	private readonly IAppQueryContext _appQueryContext;
+
+	public GetTeamInvitationsQueryHandler(IAppQueryContext appQueryContext)
+	{
+		_appQueryContext = appQueryContext;
+	}
+
+	public async Task<Result<List<TeamInvitationResponse>>> Handle(GetTeamInvitationsQuery request, CancellationToken ct)
+	{
+		var teamWithInitiator = await _appQueryContext.Teams
+			.Where(team => team.Id == request.TeamId)
+			.Select(team => new
+			{
+				Initiaotor = team.Members.FirstOrDefault(member => member.UserId == request.InitiatorId),
+			})
+			.FirstOrDefaultAsync(ct);
+
+		return await teamWithInitiator
+			.EnsureNotNull(TeamErrors.TeamNotFound)
+			.EnsureNotNull(team => team.Initiaotor, TeamErrors.NotMemberOfTeam)
+			.Ensure(team => team.Initiaotor!.Role.CanInviteTeamMembers(), TeamErrors.UnauthorizedToReadInvitationList)
+			.ThenAsync(team =>
+			{
+				return _appQueryContext.Invitations
+					.Where(invitation => invitation.TeamId == request.TeamId)
+					.Select(invitation => new TeamInvitationResponse
+					{
+						Email = _appQueryContext.Users.First(user => user.Id == invitation.RecipientId).Email,
+						CreatedUtc = invitation.CreatedUtc
+					})
+					.ToListAsync(ct);
+			});
+	}
+}

--- a/src/TeamUp.Application/Invitations/InviteUser/InvitationCreatedEventHandler.cs
+++ b/src/TeamUp.Application/Invitations/InviteUser/InvitationCreatedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using TeamUp.Common.Abstractions;
+using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Invitations.IntegrationEvents;
+
+namespace TeamUp.Application.Invitations.InviteUser;
+
+internal sealed class InvitationCreatedEventHandler : IIntegrationEventHandler<InvitationCreatedEvent>
+{
+	private readonly IEmailSender _emailSender;
+
+	public InvitationCreatedEventHandler(IEmailSender emailSender)
+	{
+		_emailSender = emailSender;
+	}
+
+	public async Task Handle(InvitationCreatedEvent integrationEvent, CancellationToken ct)
+	{
+		var subject = "TeamUp - invitation";
+		var message = $"You have been invited to team {integrationEvent.TeamName}.";
+		await _emailSender.SendEmailAsync(integrationEvent.Email, subject, message, ct);
+	}
+}

--- a/src/TeamUp.Application/Invitations/InviteUser/InviteUserCommand.cs
+++ b/src/TeamUp.Application/Invitations/InviteUser/InviteUserCommand.cs
@@ -1,0 +1,9 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Domain.Aggregates.Invitations;
+using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Application.Invitations.InviteUser;
+
+public sealed record InviteUserCommand(UserId InitiatorId, TeamId TeamId, string Email) : ICommand<Result<InvitationId>>;

--- a/src/TeamUp.Application/Invitations/InviteUser/InviteUserCommandHandler.cs
+++ b/src/TeamUp.Application/Invitations/InviteUser/InviteUserCommandHandler.cs
@@ -1,0 +1,26 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Invitations;
+using TeamUp.Domain.DomainServices;
+
+namespace TeamUp.Application.Invitations.InviteUser;
+
+internal sealed class InviteUserCommandHandler : ICommandHandler<InviteUserCommand, Result<InvitationId>>
+{
+	private readonly IInvitationDomainService _invitationDomainService;
+	private readonly IUnitOfWork _unitOfWork;
+
+	public InviteUserCommandHandler(IInvitationDomainService invitationDomainService, IUnitOfWork unitOfWork)
+	{
+		_invitationDomainService = invitationDomainService;
+		_unitOfWork = unitOfWork;
+	}
+
+	public Task<Result<InvitationId>> Handle(InviteUserCommand request, CancellationToken ct)
+	{
+		return _invitationDomainService
+			.InviteUserAsync(request.InitiatorId, request.TeamId, request.Email, ct)
+			.TapAsync(_ => _unitOfWork.SaveChangesAsync(ct));
+	}
+}

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.And.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.And.cs
@@ -1,0 +1,45 @@
+﻿namespace TeamUp.Common;
+
+public static partial class ResultExtensions
+{
+	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<TSecond> func)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		return (self.Value!, func());
+	}
+
+	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<Result<TSecond>> func)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		var result = func();
+		if (result.IsFailure)
+			return result.Error;
+
+		return (self.Value!, result.Value!);
+	}
+
+	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<TFirst, Result<TSecond>> func)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		var result = func(self.Value!);
+		if (result.IsFailure)
+			return result.Error;
+
+		return (self.Value!, result.Value!);
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> AndAsync<TFirst, TSecond>(this Result<TFirst> self, Func<TFirst, Task<TSecond>> func)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		var result = await func(self.Value!);
+		return (self.Value!, result);
+	}
+}

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.Ensure.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.Ensure.cs
@@ -48,6 +48,12 @@ public static partial class ResultExtensions
 		return self;
 	}
 
+	public static async Task<Result<TValue>> Ensure<TValue, TError>(this Task<Result<TValue>> selfTask, Rule<TValue> rule, TError error) where TError : ErrorBase
+	{
+		var self = await selfTask;
+		return self.Ensure(rule, error);
+	}
+
 	public static Result<TObj> EnsureNotNull<TObj, TError>(this TObj? self, TError error) where TError : ErrorBase
 	{
 		if (self is null)
@@ -67,6 +73,17 @@ public static partial class ResultExtensions
 		return self.Value;
 	}
 
+	public static Result<TValue> EnsureNotNull<TValue, TProperty, TError>(this Result<TValue> self, Func<TValue, TProperty?> selector, TError error) where TError : ErrorBase
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		if (selector(self.Value!) is null)
+			return error;
+
+		return self.Value;
+	}
+
 	public static Result<(TFirst, TSecond)> Ensure<TFirst, TSecond, TError>(this Result<(TFirst, TSecond)> self, Rule<TFirst, TSecond> rule, TError error) where TError : ErrorBase
 	{
 		if (self.IsFailure)
@@ -76,5 +93,25 @@ public static partial class ResultExtensions
 			return error;
 
 		return self;
+	}
+
+	public static Result<(TFirst, TSecond)> Ensure<TFirst, TSecond, TRule>(this Result<(TFirst, TSecond)> self, TRule rule) where TRule : IRuleWithError<(TFirst, TSecond)>
+	{
+		if (self.IsFailure)
+			return self;
+
+		return rule.Apply(self.Value!);
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> Ensure<TFirst, TSecond, TError>(this Task<Result<(TFirst, TSecond)>> selfTask, Rule<TFirst, TSecond> rule, TError error) where TError : ErrorBase
+	{
+		var self = await selfTask;
+		return self.Ensure(rule, error);
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> Ensure<TFirst, TSecond, TRule>(this Task<Result<(TFirst, TSecond)>> selfTask, TRule rule) where TRule : IRuleWithError<(TFirst, TSecond)>
+	{
+		var self = await selfTask;
+		return self.Ensure(rule);
 	}
 }

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.Tap.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.Tap.cs
@@ -39,6 +39,19 @@ public static partial class ResultExtensions
 		return self;
 	}
 
+	public static async Task<Result<TValue>> TapAsync<TValue>(this Task<Result<TValue>> selfTask, Func<TValue, Task> asyncFunc)
+	{
+		var self = await selfTask;
+		return await self.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result<TValue>> Tap<TValue>(this Task<Result<TValue>> selfTask, Action<TValue> func)
+	{
+		var self = await selfTask;
+		self.Tap(func);
+		return self;
+	}
+
 	public static Result<(TFirst, TSecond)> Tap<TFirst, TSecond>(this Result<(TFirst, TSecond)> self, Action<TFirst, TSecond> func)
 	{
 		if (self.IsFailure)
@@ -46,5 +59,11 @@ public static partial class ResultExtensions
 
 		func(self.Value.Item1, self.Value.Item2);
 		return self;
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> Tap<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> selfTask, Action<TFirst, TSecond> func)
+	{
+		var self = await selfTask;
+		return self.Tap(func);
 	}
 }

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.Then.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.Then.cs
@@ -26,27 +26,18 @@ public static partial class ResultExtensions
 		return mapper(self.Value!);
 	}
 
-	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Result<TValue> self, Func<TValue, Task<TOut>> mapper)
+	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Result<TValue> self, Func<TValue, Task<TOut>> asyncMapper)
 	{
 		if (self.IsFailure)
 			return self.Error;
 
-		return await mapper(self.Value!);
+		return await asyncMapper(self.Value!);
 	}
 
-	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Task<Result<TValue>> selfTask, Func<TValue, TOut> mapper)
+	public static async Task<Result<TOut>> Then<TValue, TOut>(this Task<Result<TValue>> selfTask, Func<TValue, TOut> mapper)
 	{
 		var self = await selfTask;
 		return self.Then(mapper);
-	}
-
-	public static Result Then<TFirst, TSecond>(this Result<(TFirst, TSecond)> self, Action<TFirst, TSecond> func)
-	{
-		if (self.IsFailure)
-			return self.Error;
-
-		func(self.Value.Item1, self.Value.Item2);
-		return Result.Success;
 	}
 
 	public static Result<TOut> Then<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> self, Func<TFirst, TSecond, TOut> mapper)
@@ -63,5 +54,39 @@ public static partial class ResultExtensions
 			return self.Error;
 
 		return mapper(self.Value.Item1, self.Value.Item2);
+	}
+
+	public static async Task<Result<TOut>> Then<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> selfTask, Func<TFirst, TSecond, TOut> mapper)
+	{
+		var self = await selfTask;
+		return self.Then(mapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> self, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		return await asyncMapper(self.Value!.Item1, self.Value.Item2);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> selfTask, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
+	{
+		var self = await selfTask;
+		return await self.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> self, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
+	{
+		if (self.IsFailure)
+			return self.Error;
+
+		return await asyncMapper(self.Value!.Item1, self.Value.Item2);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> selfTask, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
+	{
+		var self = await selfTask;
+		return await self.ThenAsync(asyncMapper);
 	}
 }

--- a/src/TeamUp.Common/Result/Extensions/ResultExtensions.cs
+++ b/src/TeamUp.Common/Result/Extensions/ResultExtensions.cs
@@ -14,36 +14,4 @@ public static partial class ResultExtensions
 	{
 		return (await selfTask).ToResult();
 	}
-
-	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<TSecond> func)
-	{
-		if (self.IsFailure)
-			return self.Error;
-
-		return (self.Value!, func());
-	}
-
-	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<Result<TSecond>> func)
-	{
-		if (self.IsFailure)
-			return self.Error;
-
-		var result = func();
-		if (result.IsFailure)
-			return result.Error;
-
-		return (self.Value!, result.Value!);
-	}
-
-	public static Result<(TFirst, TSecond)> And<TFirst, TSecond>(this Result<TFirst> self, Func<TFirst, Result<TSecond>> func)
-	{
-		if (self.IsFailure)
-			return self.Error;
-
-		var result = func(self.Value!);
-		if (result.IsFailure)
-			return result.Error;
-
-		return (self.Value!, result.Value!);
-	}
 }

--- a/src/TeamUp.Contracts/Invitations/InviteUserRequest.cs
+++ b/src/TeamUp.Contracts/Invitations/InviteUserRequest.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using FluentValidation;
+
+using TeamUp.Domain.Aggregates.Teams;
+
+namespace TeamUp.Contracts.Invitations;
+
+public sealed class InviteUserRequest : IRequestBody
+{
+	public required TeamId TeamId { get; init; }
+
+	[DataType(DataType.EmailAddress)]
+	public required string Email { get; init; }
+
+	public sealed class Validator : AbstractValidator<InviteUserRequest>
+	{
+		public Validator()
+		{
+			RuleFor(x => x.TeamId).NotEmpty();
+
+			RuleFor(x => x.Email)
+				.NotEmpty()
+				.EmailAddress();
+		}
+	}
+}

--- a/src/TeamUp.Contracts/Invitations/TeamInvitationResponse.cs
+++ b/src/TeamUp.Contracts/Invitations/TeamInvitationResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace TeamUp.Contracts.Invitations;
+
+public sealed class TeamInvitationResponse
+{
+	public required string Email { get; init; }
+
+	public required DateTime CreatedUtc { get; init; }
+}

--- a/src/TeamUp.Domain/Aggregates/Invitations/DomainEvents/InvitationAcceptedDomainEvent.cs
+++ b/src/TeamUp.Domain/Aggregates/Invitations/DomainEvents/InvitationAcceptedDomainEvent.cs
@@ -1,7 +1,5 @@
 ﻿using TeamUp.Domain.Abstractions;
-using TeamUp.Domain.Aggregates.Teams;
-using TeamUp.Domain.Aggregates.Users;
 
 namespace TeamUp.Domain.Aggregates.Invitations.DomainEvents;
 
-public sealed record InvitationAcceptedDomainEvent(UserId UserId, TeamId TeamId) : IDomainEvent;
+public sealed record InvitationAcceptedDomainEvent(Invitation Invitation) : IDomainEvent;

--- a/src/TeamUp.Domain/Aggregates/Invitations/IInvitationRepository.cs
+++ b/src/TeamUp.Domain/Aggregates/Invitations/IInvitationRepository.cs
@@ -1,0 +1,12 @@
+﻿using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Domain.Aggregates.Invitations;
+
+public interface IInvitationRepository
+{
+	public void AddInvitation(Invitation invitation);
+	public void RemoveInvitation(Invitation invitation);
+	public Task<Invitation?> GetInvitationByIdAsync(InvitationId invitationId, CancellationToken ct = default);
+	public Task<bool> ExistsInvitationForUserToTeamAsync(UserId userId, TeamId teamId, CancellationToken ct = default);
+}

--- a/src/TeamUp.Domain/Aggregates/Invitations/IntegrationEvents/InvitationCreatedEvent.cs
+++ b/src/TeamUp.Domain/Aggregates/Invitations/IntegrationEvents/InvitationCreatedEvent.cs
@@ -1,0 +1,7 @@
+﻿using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Domain.Aggregates.Invitations.IntegrationEvents;
+
+public sealed record InvitationCreatedEvent(UserId UserId, string Email, TeamId TeamId, string TeamName) : IIntegrationEvent;

--- a/src/TeamUp.Domain/Aggregates/Invitations/Invitation.cs
+++ b/src/TeamUp.Domain/Aggregates/Invitations/Invitation.cs
@@ -16,7 +16,7 @@ public sealed class Invitation : AggregateRoot<Invitation, InvitationId>
 	public UserId RecipientId { get; }
 	public TeamId TeamId { get; }
 
-	public DateTime CreatedUtc { get; }
+	public DateTime CreatedUtc { get; init; }
 
 #pragma warning disable CS8618 // EF Core constructor
 	private Invitation() : base() { }
@@ -39,7 +39,7 @@ public sealed class Invitation : AggregateRoot<Invitation, InvitationId>
 		if (HasExpired(dateTimeProvider))
 			return DomainError.New("Invitation has expired.", "Invitations.Expired");
 
-		AddDomainEvent(new InvitationAcceptedDomainEvent(RecipientId, TeamId));
+		AddDomainEvent(new InvitationAcceptedDomainEvent(this));
 		return Result.Success;
 	}
 

--- a/src/TeamUp.Domain/Aggregates/Invitations/InvitationFactory.cs
+++ b/src/TeamUp.Domain/Aggregates/Invitations/InvitationFactory.cs
@@ -1,4 +1,5 @@
-﻿using TeamUp.Common.Abstractions;
+﻿using TeamUp.Common;
+using TeamUp.Common.Abstractions;
 using TeamUp.Domain.Aggregates.Teams;
 using TeamUp.Domain.Aggregates.Users;
 
@@ -6,13 +7,22 @@ namespace TeamUp.Domain.Aggregates.Invitations;
 
 internal sealed class InvitationFactory
 {
+	private readonly IInvitationRepository _invitationRepository;
 	private readonly IDateTimeProvider _dateTimeProvider;
 
-	public InvitationFactory(IDateTimeProvider dateTimeProvider)
+	public InvitationFactory(IInvitationRepository invitationRepository, IDateTimeProvider dateTimeProvider)
 	{
+		_invitationRepository = invitationRepository;
 		_dateTimeProvider = dateTimeProvider;
 	}
 
-	public Invitation CreateInvitation(UserId userId, TeamId teamId) =>
-		new(InvitationId.New(), userId, teamId, _dateTimeProvider.UtcNow);
+	public async Task<Result<Invitation>> CreateInvitationAsync(UserId userId, TeamId teamId, CancellationToken ct)
+	{
+		if (await _invitationRepository.ExistsInvitationForUserToTeamAsync(userId, teamId, ct))
+		{
+			return TeamErrors.UserIsAlreadyInvited;
+		}
+
+		return new Invitation(InvitationId.New(), userId, teamId, _dateTimeProvider.UtcNow);
+	}
 }

--- a/src/TeamUp.Domain/Aggregates/Teams/Team.cs
+++ b/src/TeamUp.Domain/Aggregates/Teams/Team.cs
@@ -94,11 +94,12 @@ public sealed class Team : AggregateRoot<Team, TeamId>
 		return GetTeamMemberByUserId(initiatorId)
 			.Ensure(Rules.MemberCanChangeOwnership)
 			.And(() => GetTeamMember(memberId))
-			.Then((initiator, member) =>
+			.Tap((initiator, member) =>
 			{
 				initiator.UpdateRole(TeamRole.Admin);
 				member.UpdateRole(TeamRole.Owner);
-			});
+			})
+			.ToResult();
 	}
 
 	public Result ChangeTeamName(UserId initiatorId, string newName)

--- a/src/TeamUp.Domain/Aggregates/Teams/TeamErrors.cs
+++ b/src/TeamUp.Domain/Aggregates/Teams/TeamErrors.cs
@@ -16,8 +16,11 @@ public static class TeamErrors
 	public static readonly AuthorizationError UnauthorizedToRemoveTeamMembers = AuthorizationError.New("Not allowed to remove team members.", "Teams.NotAllowedToRemoveMembers");
 	public static readonly AuthorizationError UnauthorizedToCreateEvents = AuthorizationError.New("Not allowed to create events.", "Teams.NotAllowedToCreateEvents");
 	public static readonly AuthorizationError UnauthorizedToInviteTeamMembers = AuthorizationError.New("Not allowed to invite team members.", "Teams.NotAllowedToInviteTeamMembers");
+	public static readonly AuthorizationError UnauthorizedToReadInvitationList = AuthorizationError.New("Not allowed to read invitation list.", "Teams.NotAllowedToReadInvitations");
 	public static readonly AuthorizationError UnauthorizedToDeleteTeam = AuthorizationError.New("Not allowed to delete team.", "Teams.NotAllowedToDeleteTeam");
 	public static readonly AuthorizationError UnauthorizedToCreateEventTypes = AuthorizationError.New("Not allowed to create event types.", "Teams.NotAllowedToCreateEventTypes");
+
+	public static readonly ConflictError UserIsAlreadyInvited = ConflictError.New("User has been already invited to this team.", "Teams.UserIsAlreadyInvited");
 
 	public static readonly NotFoundError TeamNotFound = NotFoundError.New("Team not found.", "Teams.NotFound");
 	public static readonly NotFoundError MemberNotFound = NotFoundError.New("Member not found.", "Teams.Members.NotFound");
@@ -26,4 +29,5 @@ public static class TeamErrors
 	public static readonly DomainError CannotChangeTeamOwnersRole = DomainError.New("Cannot change role of the team owner.", "Teams.CannotChangeOwnersRole");
 	public static readonly DomainError CannotHaveMultipleTeamOwners = DomainError.New("Cannot have multiple team owners.", "Teams.CannotHaveMultipleOwners");
 	public static readonly DomainError CannotRemoveTeamOwner = DomainError.New("Cannot remove owner of the team.", "Teams.CannotRemoveOwner");
+	public static readonly DomainError CannotInviteUserThatIsTeamMember = DomainError.New("Cannot invite user that is already member of the team.", "Teams.CannotInviteUserThatIsTeamMember");
 }

--- a/src/TeamUp.Domain/Aggregates/Teams/TeamRules.cs
+++ b/src/TeamUp.Domain/Aggregates/Teams/TeamRules.cs
@@ -1,4 +1,5 @@
 ﻿using TeamUp.Common;
+using TeamUp.Domain.Aggregates.Users;
 
 namespace TeamUp.Domain.Aggregates.Teams;
 
@@ -29,5 +30,10 @@ public static class TeamRules
 	public static readonly RuleWithError<(TeamMember Member, TeamMember Initiator)> MemberCanBeRemovedByInitiator = new(
 		context => context.Initiator.Role.CanRemoveTeamMembers() || context.Initiator.Id == context.Member.Id,
 		TeamErrors.UnauthorizedToRemoveTeamMembers
+	);
+
+	public static readonly RuleWithError<(Team Team, User? User)> InvitedUserIsNotTeamMember = new(
+		context => context.User is null || context.Team.Members.FirstOrDefault(member => member.UserId == context.User.Id) is null,
+		TeamErrors.CannotInviteUserThatIsTeamMember
 	);
 }

--- a/src/TeamUp.Domain/DomainServices/IEventDomainService.cs
+++ b/src/TeamUp.Domain/DomainServices/IEventDomainService.cs
@@ -4,6 +4,7 @@ using TeamUp.Domain.Aggregates.Teams;
 using TeamUp.Domain.Aggregates.Users;
 
 namespace TeamUp.Domain.DomainServices;
+
 public interface IEventDomainService
 {
 	public Task<Result<Event>> CreateEventAsync(UserId loggedUserId, TeamId teamId, EventTypeId eventTypeId, DateTimeOffset from, DateTimeOffset to, string description, TimeSpan meetTime, TimeSpan replyClosingTimeBeforeMeetTime, CancellationToken ct = default);

--- a/src/TeamUp.Domain/DomainServices/IInvitationDomainService.cs
+++ b/src/TeamUp.Domain/DomainServices/IInvitationDomainService.cs
@@ -4,7 +4,8 @@ using TeamUp.Domain.Aggregates.Teams;
 using TeamUp.Domain.Aggregates.Users;
 
 namespace TeamUp.Domain.DomainServices;
+
 public interface IInvitationDomainService
 {
-	public Task<Result<Invitation>> InviteUserAsync(UserId loggedUserId, TeamId teamId, string email, CancellationToken ct = default);
+	public Task<Result<InvitationId>> InviteUserAsync(UserId initiatorId, TeamId teamId, string email, CancellationToken ct = default);
 }

--- a/src/TeamUp.Domain/DomainServices/InvitationDomainService.cs
+++ b/src/TeamUp.Domain/DomainServices/InvitationDomainService.cs
@@ -1,5 +1,7 @@
 ﻿using TeamUp.Common;
+using TeamUp.Domain.Abstractions;
 using TeamUp.Domain.Aggregates.Invitations;
+using TeamUp.Domain.Aggregates.Invitations.IntegrationEvents;
 using TeamUp.Domain.Aggregates.Teams;
 using TeamUp.Domain.Aggregates.Users;
 
@@ -9,27 +11,48 @@ internal sealed class InvitationDomainService : IInvitationDomainService
 {
 	private readonly IUserRepository _userRepository;
 	private readonly ITeamRepository _teamRepository;
+	private readonly IInvitationRepository _invitationRepository;
+	private readonly IIntegrationEventManager _integrationEventManager;
 	private readonly InvitationFactory _invitationFactory;
 
 	public InvitationDomainService(
 		IUserRepository userRepository,
 		ITeamRepository teamRepository,
+		IInvitationRepository invitationRepository,
+		IIntegrationEventManager integrationEventManager,
 		InvitationFactory invitationFactory)
 	{
 		_userRepository = userRepository;
 		_teamRepository = teamRepository;
+		_invitationRepository = invitationRepository;
+		_integrationEventManager = integrationEventManager;
 		_invitationFactory = invitationFactory;
 	}
 
-	public async Task<Result<Invitation>> InviteUserAsync(UserId loggedUserId, TeamId teamId, string email, CancellationToken ct = default)
+	public async Task<Result<InvitationId>> InviteUserAsync(UserId initiatorId, TeamId teamId, string email, CancellationToken ct = default)
 	{
 		var team = await _teamRepository.GetTeamByIdAsync(teamId, ct);
 		return await team
 			.EnsureNotNull(TeamErrors.TeamNotFound)
-			.Then(team => team.GetTeamMemberByUserId(loggedUserId))
-			.Ensure(member => member.Role.CanInviteTeamMembers(), TeamErrors.UnauthorizedToInviteTeamMembers)
-			.ThenAsync(_ => _userRepository.GetUserByEmailAsync(email, ct))
-			.ThenAsync(user => user ?? User.Generate(email))
-			.ThenAsync(user => _invitationFactory.CreateInvitation(user.Id, teamId));
+			.And(team => team.GetTeamMemberByUserId(initiatorId))
+			.Ensure((_, member) => member.Role.CanInviteTeamMembers(), TeamErrors.UnauthorizedToInviteTeamMembers)
+			.Then((team, _) => team)
+			.AndAsync(team => _userRepository.GetUserByEmailAsync(email, ct))
+			.Ensure(TeamRules.InvitedUserIsNotTeamMember)
+			.Then((team, user) =>
+			{
+				if (user is null)
+				{
+					var generatedUser = User.Generate(email);
+					_userRepository.AddUser(generatedUser);
+					return (team, generatedUser);
+				}
+
+				return (team, user);
+			})
+			.Tap((team, user) => _integrationEventManager.AddIntegrationEvent(new InvitationCreatedEvent(user.Id, user.Email, team.Id, team.Name)))
+			.ThenAsync((team, user) => _invitationFactory.CreateInvitationAsync(user.Id, team.Id, ct))
+			.Tap(_invitationRepository.AddInvitation)
+			.Then(invitation => invitation.Id);
 	}
 }

--- a/src/TeamUp.Domain/EventHandlers/InvitationAcceptedEventHandler.cs
+++ b/src/TeamUp.Domain/EventHandlers/InvitationAcceptedEventHandler.cs
@@ -2,6 +2,7 @@
 
 using TeamUp.Common.Abstractions;
 using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Invitations;
 using TeamUp.Domain.Aggregates.Invitations.DomainEvents;
 using TeamUp.Domain.Aggregates.Users;
 
@@ -12,36 +13,40 @@ internal sealed class InvitationAcceptedEventHandler : IDomainEventHandler<Invit
 	private readonly ITeamRepository _teamRepository;
 	private readonly IUserRepository _userRepository;
 	private readonly IDateTimeProvider _dateTimeProvider;
+	private readonly IInvitationRepository _invitationRepository;
 	private readonly ILogger<InvitationAcceptedEventHandler> _logger;
 
 	public InvitationAcceptedEventHandler(
 		ITeamRepository teamRepository,
 		IUserRepository userRepository,
 		IDateTimeProvider dateTimeProvider,
+		IInvitationRepository invitationRepository,
 		ILogger<InvitationAcceptedEventHandler> logger)
 	{
 		_teamRepository = teamRepository;
 		_userRepository = userRepository;
 		_dateTimeProvider = dateTimeProvider;
+		_invitationRepository = invitationRepository;
 		_logger = logger;
 	}
 
 	public async Task Handle(InvitationAcceptedDomainEvent domainEvent, CancellationToken ct)
 	{
-		var user = await _userRepository.GetUserByIdAsync(domainEvent.UserId, ct);
+		var user = await _userRepository.GetUserByIdAsync(domainEvent.Invitation.RecipientId, ct);
 		if (user is null)
 		{
-			_logger.LogWarning("Accepted invitation for user ({userId}) that doesn't exist.", domainEvent.UserId);
+			_logger.LogWarning("Accepted invitation by user ({userId}) that doesn't exist.", domainEvent.Invitation.RecipientId);
 			return;
 		}
 
-		var team = await _teamRepository.GetTeamByIdAsync(domainEvent.TeamId, ct);
+		var team = await _teamRepository.GetTeamByIdAsync(domainEvent.Invitation.TeamId, ct);
 		if (team is null)
 		{
-			_logger.LogWarning("Accepted invitation for team ({teamId}) that doesn't exist.", domainEvent.TeamId);
+			_logger.LogWarning("Accepted invitation for team ({teamId}) that doesn't exist.", domainEvent.Invitation.TeamId);
 			return;
 		}
 
 		team.AddTeamMember(user, _dateTimeProvider);
+		_invitationRepository.RemoveInvitation(domainEvent.Invitation);
 	}
 }

--- a/src/TeamUp.Domain/ServiceCollectionExtensions.cs
+++ b/src/TeamUp.Domain/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class ServiceCollectionExtensions
 			.AddScoped<ITeamDomainService, TeamDomainService>();
 
 		services
-			.AddSingleton<InvitationFactory>()
+			.AddScoped<InvitationFactory>()
 			.AddScoped<UserFactory>();
 
 		return services;

--- a/src/TeamUp.Infrastructure/Persistence/Domain/Invitations/InvittionRepository.cs
+++ b/src/TeamUp.Infrastructure/Persistence/Domain/Invitations/InvittionRepository.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using TeamUp.Domain.Aggregates.Invitations;
+using TeamUp.Domain.Aggregates.Teams;
+using TeamUp.Domain.Aggregates.Users;
+
+namespace TeamUp.Infrastructure.Persistence.Domain.Invitations;
+
+internal sealed class InvitationRepository : IInvitationRepository
+{
+	private readonly ApplicationDbContext _dbContext;
+
+	public InvitationRepository(ApplicationDbContext dbContext)
+	{
+		_dbContext = dbContext;
+	}
+
+	public void AddInvitation(Invitation invitation) => _dbContext.Invitations.Add(invitation);
+
+	public void RemoveInvitation(Invitation invitation) => _dbContext.Invitations.Remove(invitation);
+
+	public async Task<Invitation?> GetInvitationByIdAsync(InvitationId invitationId, CancellationToken ct = default)
+	{
+		return await _dbContext.Invitations.FindAsync([invitationId], ct);
+	}
+
+	public async Task<bool> ExistsInvitationForUserToTeamAsync(UserId userId, TeamId teamId, CancellationToken ct = default)
+	{
+		return await _dbContext.Invitations.AnyAsync(invitation => invitation.RecipientId == userId && invitation.TeamId == teamId, ct);
+	}
+}

--- a/src/TeamUp.Infrastructure/Persistence/Migrations/20240221164444_InvitationTimeStampFix.Designer.cs
+++ b/src/TeamUp.Infrastructure/Persistence/Migrations/20240221164444_InvitationTimeStampFix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeamUp.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using TeamUp.Infrastructure.Persistence;
 namespace TeamUp.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240221164444_InvitationTimeStampFix")]
+    partial class InvitationTimeStampFix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TeamUp.Infrastructure/Persistence/Migrations/20240221164444_InvitationTimeStampFix.cs
+++ b/src/TeamUp.Infrastructure/Persistence/Migrations/20240221164444_InvitationTimeStampFix.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeamUp.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvitationTimeStampFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedUtc",
+                table: "Invitations",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedUtc",
+                table: "Invitations");
+        }
+    }
+}

--- a/src/TeamUp.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/TeamUp.Infrastructure/ServiceCollectionExtensions.cs
@@ -9,11 +9,13 @@ using TeamUp.Application.Abstractions;
 using TeamUp.Application.Users;
 using TeamUp.Common.Abstractions;
 using TeamUp.Domain.Abstractions;
+using TeamUp.Domain.Aggregates.Invitations;
 using TeamUp.Domain.Aggregates.Teams;
 using TeamUp.Domain.Aggregates.Users;
 using TeamUp.Infrastructure.Core;
 using TeamUp.Infrastructure.Options;
 using TeamUp.Infrastructure.Persistence;
+using TeamUp.Infrastructure.Persistence.Domain.Invitations;
 using TeamUp.Infrastructure.Persistence.Domain.Teams;
 using TeamUp.Infrastructure.Persistence.Domain.Users;
 using TeamUp.Infrastructure.Processing;
@@ -57,6 +59,7 @@ public static class ServiceCollectionExtensions
 			.AddSingleton<IPasswordService, PasswordService>()
 			.AddScoped<IUserRepository, UserRepository>()
 			.AddScoped<ITeamRepository, TeamRepository>()
+			.AddScoped<IInvitationRepository, InvitationRepository>()
 			.AddScoped<IAppQueryContext, ApplicationDbContextQueryFacade>();
 
 		//db context

--- a/tests/TeamUp.EndToEndTests/DataGenerators/InvitationGenerator.cs
+++ b/tests/TeamUp.EndToEndTests/DataGenerators/InvitationGenerator.cs
@@ -1,0 +1,71 @@
+﻿using TeamUp.Contracts.Invitations;
+
+namespace TeamUp.EndToEndTests.DataGenerators;
+
+public sealed class InvitationGenerator : BaseGenerator
+{
+	private static readonly PrivateBinder InvitationBinder = new(
+		nameof(Invitation.RecipientId).GetBackingField(),
+		nameof(Invitation.TeamId).GetBackingField()
+	);
+
+	public static readonly Faker<Invitation> EmptyInvitation = new Faker<Invitation>(binder: InvitationBinder)
+		.UsePrivateConstructor()
+		.RuleFor(i => i.Id, f => InvitationId.FromGuid(f.Random.Guid()));
+
+	public static Invitation GenerateInvitation(UserId userId, TeamId teamId, DateTime createdUtc)
+	{
+		return EmptyInvitation
+			.RuleForBackingField(i => i.RecipientId, userId)
+			.RuleForBackingField(i => i.TeamId, teamId)
+			.RuleFor(i => i.CreatedUtc, createdUtc)
+			.Generate();
+	}
+
+	public static List<Invitation> GenerateInvitations(TeamId teamId, DateTime createdUtc, List<User> users)
+	{
+		return users.Select(user =>
+			EmptyInvitation
+				.RuleForBackingField(i => i.RecipientId, user.Id)
+				.RuleForBackingField(i => i.TeamId, teamId)
+				.RuleFor(i => i.CreatedUtc, createdUtc)
+				.Generate()
+		).ToList();
+	}
+
+	public sealed class InvalidInviteUserRequest : TheoryData<InvalidRequest<InviteUserRequest>>
+	{
+		public InvalidInviteUserRequest()
+		{
+			this.Add(x => x.Email, new InviteUserRequest
+			{
+				TeamId = TeamId.FromGuid(F.Random.Guid()),
+				Email = ""
+			});
+
+			this.Add(x => x.Email, new InviteUserRequest
+			{
+				TeamId = TeamId.FromGuid(F.Random.Guid()),
+				Email = "@@"
+			});
+
+			this.Add(x => x.Email, new InviteUserRequest
+			{
+				TeamId = TeamId.FromGuid(F.Random.Guid()),
+				Email = "invalid email"
+			});
+
+			this.Add(x => x.Email, new InviteUserRequest
+			{
+				TeamId = TeamId.FromGuid(F.Random.Guid()),
+				Email = "missing.domain@"
+			});
+
+			this.Add(x => x.Email, new InviteUserRequest
+			{
+				TeamId = TeamId.FromGuid(F.Random.Guid()),
+				Email = "@missing.username"
+			});
+		}
+	}
+}

--- a/tests/TeamUp.EndToEndTests/DataGenerators/TeamGenerator.cs
+++ b/tests/TeamUp.EndToEndTests/DataGenerators/TeamGenerator.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-
-using TeamUp.Contracts.Teams;
-using TeamUp.Contracts.Users;
+﻿using TeamUp.Contracts.Teams;
 
 namespace TeamUp.EndToEndTests.DataGenerators;
 
@@ -44,6 +41,17 @@ public sealed class TeamGenerator : BaseGenerator
 					.Generate()
 			})
 			.Generate();
+	}
+
+	public static Team GenerateTeamWith(User user, TeamRole role, List<User> members)
+	{
+		(role != TeamRole.Owner && members.Count == 0).Should().Be(false, "team has to have exactly 1 owner");
+
+		return role switch
+		{
+			TeamRole.Owner => GenerateTeamWith(members, (user, TeamRole.Owner)),
+			_ => GenerateTeamWith(members[1..], (members.First(), TeamRole.Owner), (user, role))
+		};
 	}
 
 	public static Team GenerateTeamWith(User owner, List<User> members, params (User User, TeamRole Role)[] userMembers)

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/BaseInvitationTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/BaseInvitationTests.cs
@@ -1,0 +1,6 @@
+﻿namespace TeamUp.EndToEndTests.EndpointTests.Invitations;
+
+public abstract class BaseInvitationTests : BaseEndpointTests
+{
+	public BaseInvitationTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+}

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/GetTeamInvitationsTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/GetTeamInvitationsTests.cs
@@ -1,0 +1,130 @@
+﻿using TeamUp.Contracts.Invitations;
+
+namespace TeamUp.EndToEndTests.EndpointTests.Invitations;
+
+public sealed class GetTeamInvitationsTests : BaseInvitationTests
+{
+	public GetTeamInvitationsTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+
+	[Theory]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	[InlineData(TeamRole.Owner)]
+	public async Task GetTeamInvitations_AsCoordinatorOrHigher_Should_ReturnListOfInvitations(TeamRole teamRole)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, teamRole, members);
+
+		//need to remove milliseconds as when saving to database, there is slight shift
+		var utcNow = new DateTime(DateTime.UtcNow.Ticks / TimeSpan.TicksPerSecond * TimeSpan.TicksPerSecond, DateTimeKind.Utc);
+		var invitations = InvitationGenerator.GenerateInvitations(team.Id, utcNow, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(initiatorUser);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			dbContext.Invitations.AddRange(invitations);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+
+		//assert
+		response.Should().Be200Ok();
+
+		var teamInvitations = await response.Content.ReadFromJsonAsync<List<TeamInvitationResponse>>();
+		invitations.Should().BeEquivalentTo(teamInvitations, o => o.ExcludingMissingMembers());
+	}
+
+	[Fact]
+	public async Task GetTeamInvitations_AsMember_Should_ResultInForbidden()
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, TeamRole.Member, members);
+		var invitations = InvitationGenerator.GenerateInvitations(team.Id, DateTime.UtcNow, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(initiatorUser);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			dbContext.Invitations.AddRange(invitations);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+
+		//assert
+		response.Should().Be403Forbidden();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.UnauthorizedToReadInvitationList);
+	}
+
+	[Fact]
+	public async Task GetTeamInvitations_WhenNotMemberOfTeam_Should_ResultInForbidden()
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(owner, members);
+		var invitations = InvitationGenerator.GenerateInvitations(team.Id, DateTime.UtcNow, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, initiatorUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			dbContext.Invitations.AddRange(invitations);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+
+		//assert
+		response.Should().Be403Forbidden();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.NotMemberOfTeam);
+	}
+
+	[Fact]
+	public async Task GetTeamInvitations_OfUnExistingTeam_Should_ResultInNotFound()
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var teamId = F.Random.Guid();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(initiatorUser);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.GetAsync($"/api/v1/invitations/teams/{teamId}");
+
+		//assert
+		response.Should().Be404NotFound();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.TeamNotFound);
+	}
+}

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/InviteUserTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/InviteUserTests.cs
@@ -1,0 +1,314 @@
+﻿using TeamUp.Contracts.Invitations;
+
+namespace TeamUp.EndToEndTests.EndpointTests.Invitations;
+
+public sealed class InviteUserTests : BaseInvitationTests
+{
+	public InviteUserTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+
+	[Theory]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	[InlineData(TeamRole.Owner)]
+	public async Task InviteUser_ThatIsActivated_AsCoordinatorOrHigher_Should_CreateInvitationInDatabase_And_SendInvitationEmail(TeamRole teamRole)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, teamRole, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be201Created();
+
+		var invitationId = await response.Content.ReadFromJsonAsync<InvitationId>();
+		invitationId.ShouldNotBeNull();
+
+		var invitation = await UseDbContextAsync(dbContext => dbContext.Invitations.FindAsync(invitationId));
+		invitation.ShouldNotBeNull();
+		invitation.TeamId.Should().Be(team.Id);
+		invitation.RecipientId.Should().Be(targetUser.Id);
+
+		await WaitForIntegrationEventsAsync(); //wait for email
+
+		Inbox.Should().Contain(email => email.EmailAddress == targetUser.Email);
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	[InlineData(TeamRole.Owner)]
+	public async Task InviteUser_ThatIsNotRegistered_AsCoordinatorOrHigher_Should_CreateInvitationInDatabase_And_GenerateNewUser_And_SendInvitationEmail(TeamRole teamRole)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, teamRole, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(initiatorUser);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var targetEmail = F.Internet.Email();
+		var request = new InviteUserRequest
+		{
+			Email = targetEmail,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be201Created();
+
+		var invitationId = await response.Content.ReadFromJsonAsync<InvitationId>();
+		invitationId.ShouldNotBeNull();
+
+		await UseDbContextAsync(async dbContext =>
+		{
+			var invitation = await dbContext.Invitations.FindAsync(invitationId);
+			invitation.ShouldNotBeNull();
+			invitation.TeamId.Should().Be(team.Id);
+
+			var user = await dbContext.Users.FindAsync(invitation.RecipientId);
+			user.ShouldNotBeNull();
+			user.Email.Should().Be(targetEmail);
+			user.Status.Should().Be(UserStatus.Generated);
+		});
+
+		await WaitForIntegrationEventsAsync(); //wait for email
+
+		Inbox.Should().Contain(email => email.EmailAddress == targetEmail);
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	[InlineData(TeamRole.Owner)]
+	public async Task InviteUser_ThatIsAlreadyInTeam_AsCoordinatorOrHigher_Should_ResultInBadRequest(TeamRole teamRole)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, teamRole, members);
+		var targetUser = members.First();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.Add(initiatorUser);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be400BadRequest();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.CannotInviteUserThatIsTeamMember);
+	}
+
+	[Fact]
+	public async Task InviteUser_AsTeamMember_Should_ResultInForbidden()
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, TeamRole.Member, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be403Forbidden();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.UnauthorizedToInviteTeamMembers);
+	}
+
+	[Theory]
+	[InlineData(TeamRole.Coordinator)]
+	[InlineData(TeamRole.Admin)]
+	[InlineData(TeamRole.Owner)]
+	public async Task InviteUser_ThatIsAlreadyInvited_AsCoordinatorOrHigher_Should_ResultInConflict(TeamRole teamRole)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(initiatorUser, teamRole, members);
+		var invitation = InvitationGenerator.GenerateInvitation(targetUser.Id, team.Id, DateTime.UtcNow);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			dbContext.Invitations.Add(invitation);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be409Conflict();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.UserIsAlreadyInvited);
+	}
+
+	[Fact]
+	public async Task InviteUser_WhenNotMemberOfTeam_Should_ResultInForbidden()
+	{
+		//arrange
+		var owner = UserGenerator.ActivatedUser.Generate();
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+		var members = UserGenerator.ActivatedUser.Generate(19);
+		var team = TeamGenerator.GenerateTeamWith(owner, members);
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([owner, initiatorUser, targetUser]);
+			dbContext.Users.AddRange(members);
+			dbContext.Teams.Add(team);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = team.Id
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be403Forbidden();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.NotMemberOfTeam);
+	}
+
+	[Fact]
+	public async Task InviteUser_ToUnExistingTeam_Should_ResultInNotFound()
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+		var targetUser = UserGenerator.ActivatedUser.Generate();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange([initiatorUser, targetUser]);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		var request = new InviteUserRequest
+		{
+			Email = targetUser.Email,
+			TeamId = TeamId.FromGuid(F.Random.Guid())
+		};
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+
+		//assert
+		response.Should().Be404NotFound();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+		problemDetails.ShouldContainError(TeamErrors.TeamNotFound);
+	}
+
+	[Theory]
+	[ClassData(typeof(InvitationGenerator.InvalidInviteUserRequest))]
+	public async Task InviteUser_WithInvalidRequest_Should_ResultInBadRequest(InvalidRequest<InviteUserRequest> request)
+	{
+		//arrange
+		var initiatorUser = UserGenerator.ActivatedUser.Generate();
+
+		await UseDbContextAsync(dbContext =>
+		{
+			dbContext.Users.AddRange(initiatorUser);
+			return dbContext.SaveChangesAsync();
+		});
+
+		Authenticate(initiatorUser);
+
+		//act
+		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request.Request);
+
+		//assert
+		response.Should().Be400BadRequest();
+
+		var problemDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+		problemDetails.ShouldContainValidationErrorFor(request.InvalidProperty);
+	}
+}


### PR DESCRIPTION
- added invite user contract, endpoint, command and command handler
- fixed invitation service and invitation factory
- added/refactored result pattern to meet requirements and have better readability
- added get team invitations endpoint, query and query handler
- added invite user tests
- added get team invitations tests
- fixed missing db field for invitation timestamp (added migration)
- various fixes (naming, formatting ...)