### PR TITLE
Refactoring - Endpoint Tests, Naming, Team Endpoint Urls

### DIFF
--- a/src/TeamUp.Api/Endpoints/Invitations/AcceptInvitaionEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/AcceptInvitaionEndpoint.cs
@@ -28,7 +28,7 @@ public sealed class AcceptInvitationEndpoint : IEndpointGroup
 		[FromServices] IHttpContextAccessor httpContextAccessor,
 		CancellationToken ct)
 	{
-		var command = new AcceptInvitationCommand(httpContextAccessor.GetLoggedUserId(), InvitationId.FromGuid(invitationId));
+		var command = new AcceptInvitationCommand(httpContextAccessor.GetCurrentUserId(), InvitationId.FromGuid(invitationId));
 		var result = await sender.Send(command, ct);
 		return result.Match(TypedResults.Ok);
 	}

--- a/src/TeamUp.Api/Endpoints/Invitations/AcceptInvitaionEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/AcceptInvitaionEndpoint.cs
@@ -18,8 +18,8 @@ public sealed class AcceptInvitationEndpoint : IEndpointGroup
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
 			.ProducesProblem(StatusCodes.Status403Forbidden)
 			.ProducesProblem(StatusCodes.Status404NotFound)
-			.MapToApiVersion(1)
-			.WithName(nameof(AcceptInvitationEndpoint));
+			.WithName(nameof(AcceptInvitationEndpoint))
+			.MapToApiVersion(1);
 	}
 
 	private async Task<IResult> AcceptInvitationAsync(

--- a/src/TeamUp.Api/Endpoints/Invitations/GetTeamInvitationsEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/GetTeamInvitationsEndpoint.cs
@@ -28,7 +28,7 @@ public sealed class GetTeamInvitationsEndpoint : IEndpointGroup
 		[FromServices] IHttpContextAccessor httpContextAccessor,
 		CancellationToken ct)
 	{
-		var query = new GetTeamInvitationsQuery(httpContextAccessor.GetLoggedUserId(), TeamId.FromGuid(teamId));
+		var query = new GetTeamInvitationsQuery(httpContextAccessor.GetCurrentUserId(), TeamId.FromGuid(teamId));
 		var result = await sender.Send(query, ct);
 		return result.Match(TypedResults.Ok);
 	}

--- a/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
@@ -29,7 +29,7 @@ public sealed class InviteUserEndpoint : IEndpointGroup
 		[FromServices] LinkGenerator linkGenerator,
 		CancellationToken ct)
 	{
-		var command = new InviteUserCommand(httpContextAccessor.GetLoggedUserId(), request.TeamId, request.Email);
+		var command = new InviteUserCommand(httpContextAccessor.GetCurrentUserId(), request.TeamId, request.Email);
 
 		var result = await sender.Send(command, ct);
 		return result.Match(invitationId => TypedResults.Created(

--- a/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Invitations/InviteUserEndpoint.cs
@@ -14,12 +14,12 @@ public sealed class InviteUserEndpoint : IEndpointGroup
 	{
 		group.MapPost("/", InviteUserAsync)
 			.Produces<InvitationId>(StatusCodes.Status201Created)
-			.Produces(StatusCodes.Status401Unauthorized)
-			.Produces(StatusCodes.Status403Forbidden)
-			.Produces(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesValidationProblem()
-			.MapToApiVersion(1)
-			.WithName(nameof(InviteUserEndpoint));
+			.WithName(nameof(InviteUserEndpoint))
+			.MapToApiVersion(1);
 	}
 
 	private async Task<IResult> InviteUserAsync(

--- a/src/TeamUp.Api/Endpoints/Teams/ChangeNicknameEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/ChangeNicknameEndpoint.cs
@@ -30,7 +30,7 @@ public sealed class ChangeNicknameEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new ChangeNicknameCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			request.Nickname
 		);

--- a/src/TeamUp.Api/Endpoints/Teams/ChangeOwnerShipEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/ChangeOwnerShipEndpoint.cs
@@ -29,7 +29,7 @@ public class ChangeOwnershipEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new ChangeOwnershipCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			TeamMemberId.FromGuid(teamMemberId)
 		);

--- a/src/TeamUp.Api/Endpoints/Teams/CreateEventTypeEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/CreateEventTypeEndpoint.cs
@@ -31,7 +31,7 @@ public sealed class CreateEventTypeEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new CreateEventTypeCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			request.Name,
 			request.Description

--- a/src/TeamUp.Api/Endpoints/Teams/CreateEventTypeEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/CreateEventTypeEndpoint.cs
@@ -14,9 +14,9 @@ public sealed class CreateEventTypeEndpoint : IEndpointGroup
 	{
 		group.MapPost("/{teamId:guid}/event-types", CreateEventTypeAsync)
 			.Produces<EventTypeId>(StatusCodes.Status201Created)
-			.Produces(StatusCodes.Status401Unauthorized)
-			.Produces(StatusCodes.Status403Forbidden)
-			.Produces(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status401Unauthorized)
+			.ProducesProblem(StatusCodes.Status403Forbidden)
+			.ProducesProblem(StatusCodes.Status404NotFound)
 			.ProducesValidationProblem()
 			.WithName(nameof(CreateEventTypeEndpoint))
 			.MapToApiVersion(1);

--- a/src/TeamUp.Api/Endpoints/Teams/CreateTeamEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/CreateTeamEndpoint.cs
@@ -26,7 +26,7 @@ public sealed class CreateTeamEndpoint : IEndpointGroup
 		[FromServices] LinkGenerator linkGenerator,
 		CancellationToken ct)
 	{
-		var command = new CreateTeamCommand(httpContextAccessor.GetLoggedUserId(), request.Name);
+		var command = new CreateTeamCommand(httpContextAccessor.GetCurrentUserId(), request.Name);
 		var result = await sender.Send(command, ct);
 		return result.Match(teamId => TypedResults.Created(
 			uri: linkGenerator.GetPathByName(nameof(GetTeamEndpoint), teamId.Value),

--- a/src/TeamUp.Api/Endpoints/Teams/DeleteTeamEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/DeleteTeamEndpoint.cs
@@ -27,7 +27,7 @@ public sealed class DeleteTeamEndpoint : IEndpointGroup
 		[FromServices] IHttpContextAccessor httpContextAccessor,
 		CancellationToken ct)
 	{
-		var command = new DeleteTeamCommand(httpContextAccessor.GetLoggedUserId(), TeamId.FromGuid(teamId));
+		var command = new DeleteTeamCommand(httpContextAccessor.GetCurrentUserId(), TeamId.FromGuid(teamId));
 		var result = await sender.Send(command, ct);
 		return result.Match(TypedResults.Ok);
 	}

--- a/src/TeamUp.Api/Endpoints/Teams/GetTeamEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/GetTeamEndpoint.cs
@@ -27,7 +27,7 @@ public sealed class GetTeamEndpoint : IEndpointGroup
 		[FromServices] IHttpContextAccessor httpContextAccessor,
 		CancellationToken ct)
 	{
-		var query = new GetTeamQuery(httpContextAccessor.GetLoggedUserId(), TeamId.FromGuid(teamId));
+		var query = new GetTeamQuery(httpContextAccessor.GetCurrentUserId(), TeamId.FromGuid(teamId));
 		var result = await sender.Send(query, ct);
 		return result.Match(TypedResults.Ok);
 	}

--- a/src/TeamUp.Api/Endpoints/Teams/RemoveTeamMemberEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/RemoveTeamMemberEndpoint.cs
@@ -12,7 +12,7 @@ public sealed class RemoveTeamMemberEndpoint : IEndpointGroup
 {
 	public void MapEndpoints(RouteGroupBuilder group)
 	{
-		group.MapDelete("/{teamId:guid}/{teamMemberId:guid}", RemoveTeamMemberAsync)
+		group.MapDelete("/{teamId:guid}/members/{teamMemberId:guid}", RemoveTeamMemberAsync)
 			.Produces(StatusCodes.Status200OK)
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -30,7 +30,7 @@ public sealed class RemoveTeamMemberEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new RemoveTeamMemberCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			TeamMemberId.FromGuid(teamMemberId)
 		);

--- a/src/TeamUp.Api/Endpoints/Teams/UpdateTeamMemberRoleEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/UpdateTeamMemberRoleEndpoint.cs
@@ -12,7 +12,7 @@ public sealed class UpdateTeamMemberRoleEndpoint : IEndpointGroup
 {
 	public void MapEndpoints(RouteGroupBuilder group)
 	{
-		group.MapPut("/{teamId:guid}/{teamMemberId:guid}/role", UpdateTeamRoleAsync)
+		group.MapPut("/{teamId:guid}/members/{teamMemberId:guid}/role", UpdateTeamRoleAsync)
 			.Produces(StatusCodes.Status200OK)
 			.ProducesProblem(StatusCodes.Status400BadRequest)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -32,7 +32,7 @@ public sealed class UpdateTeamMemberRoleEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new SetMemberRoleCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			TeamMemberId.FromGuid(teamMemberId),
 			request.Role

--- a/src/TeamUp.Api/Endpoints/Teams/UpdateTeamNameEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/Teams/UpdateTeamNameEndpoint.cs
@@ -30,7 +30,7 @@ public sealed class UpdateTeamNameEndpoint : IEndpointGroup
 		CancellationToken ct)
 	{
 		var command = new SetTeamNameCommand(
-			httpContextAccessor.GetLoggedUserId(),
+			httpContextAccessor.GetCurrentUserId(),
 			TeamId.FromGuid(teamId),
 			request.Name
 		);

--- a/src/TeamUp.Api/Endpoints/UserAccess/GetMyAccountDetailsEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/UserAccess/GetMyAccountDetailsEndpoint.cs
@@ -3,29 +3,29 @@
 using Microsoft.AspNetCore.Mvc;
 
 using TeamUp.Api.Extensions;
-using TeamUp.Application.Users.GetUserDetail;
+using TeamUp.Application.Users.GetAccountDetails;
 using TeamUp.Contracts.Users;
 
 namespace TeamUp.Api.Endpoints.UserAccess;
 
-public sealed class GetUserDetailsEndpoint : IEndpointGroup
+public sealed class GetMyAccountDetailsEndpoint : IEndpointGroup
 {
 	public void MapEndpoints(RouteGroupBuilder group)
 	{
-		group.MapGet("/", GetUserDetailsAsync)
-			.Produces<UserResponse>(StatusCodes.Status200OK)
+		group.MapGet("/", GetAccountDetailsAsync)
+			.Produces<AccountResponse>(StatusCodes.Status200OK)
 			.ProducesProblem(StatusCodes.Status401Unauthorized)
-			.WithName(nameof(GetUserDetailsEndpoint))
+			.WithName(nameof(GetMyAccountDetailsEndpoint))
 			.MapToApiVersion(1)
 			.RequireAuthorization();
 	}
 
-	private async Task<IResult> GetUserDetailsAsync(
+	private async Task<IResult> GetAccountDetailsAsync(
 		[FromServices] ISender sender,
 		[FromServices] IHttpContextAccessor httpContextAccessor,
 		CancellationToken ct)
 	{
-		var query = new GetUserDetailsQuery(httpContextAccessor.GetLoggedUserId());
+		var query = new GetAccountDetailsQuery(httpContextAccessor.GetCurrentUserId());
 		var result = await sender.Send(query, ct);
 		return result.Match(TypedResults.Ok);
 	}

--- a/src/TeamUp.Api/Endpoints/UserAccess/RegisterUserEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/UserAccess/RegisterUserEndpoint.cs
@@ -14,6 +14,7 @@ public sealed class RegisterUserEndpoint : IEndpointGroup
 	{
 		group.MapPost("/register", RegisterUserAsync)
 			.Produces<UserId>(StatusCodes.Status201Created)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.ProducesValidationProblem()
 			.WithName(nameof(RegisterUserEndpoint))
 			.MapToApiVersion(1);

--- a/src/TeamUp.Api/Endpoints/UserAccess/RegisterUserEndpoint.cs
+++ b/src/TeamUp.Api/Endpoints/UserAccess/RegisterUserEndpoint.cs
@@ -30,7 +30,7 @@ public sealed class RegisterUserEndpoint : IEndpointGroup
 		var command = mapper.ToCommand(request);
 		var result = await sender.Send(command, ct);
 		return result.Match(
-			userId => TypedResults.Created(linkGenerator.GetPathByName(nameof(GetUserDetailsEndpoint)), userId)
+			userId => TypedResults.Created(linkGenerator.GetPathByName(nameof(GetMyAccountDetailsEndpoint)), userId)
 		);
 	}
 }

--- a/src/TeamUp.Api/Endpoints/UserAccessEndpointGroup.cs
+++ b/src/TeamUp.Api/Endpoints/UserAccessEndpointGroup.cs
@@ -10,6 +10,6 @@ public sealed class UserAccessEndpointGroup : IEndpointGroup
 		group.MapEndpoint<RegisterUserEndpoint>()
 			.MapEndpoint<ActivateAccountEndpoint>()
 			.MapEndpoint<LoginUserEndpoint>()
-			.MapEndpoint<GetUserDetailsEndpoint>();
+			.MapEndpoint<GetMyAccountDetailsEndpoint>();
 	}
 }

--- a/src/TeamUp.Api/Extensions/HttpContextExtensions.cs
+++ b/src/TeamUp.Api/Extensions/HttpContextExtensions.cs
@@ -7,7 +7,7 @@ namespace TeamUp.Api.Extensions;
 
 public static class HttpContextExtensions
 {
-	public static UserId GetLoggedUserId(this IHttpContextAccessor contextAccessor) =>
+	public static UserId GetCurrentUserId(this IHttpContextAccessor contextAccessor) =>
 		UserId.FromGuid(contextAccessor.ParseClaim(ClaimTypes.NameIdentifier, Guid.Parse));
 
 	public static TOut ParseClaim<TOut>(this IHttpContextAccessor contextAccessor, string type, Func<string, TOut> parse)

--- a/src/TeamUp.Application/Users/GetAccountDetails/GetAccountDetailsQuery.cs
+++ b/src/TeamUp.Application/Users/GetAccountDetails/GetAccountDetailsQuery.cs
@@ -1,0 +1,7 @@
+﻿using TeamUp.Application.Abstractions;
+using TeamUp.Common;
+using TeamUp.Contracts.Users;
+
+namespace TeamUp.Application.Users.GetAccountDetails;
+
+public sealed record GetAccountDetailsQuery(UserId UserId) : IQuery<Result<AccountResponse>>;

--- a/src/TeamUp.Application/Users/GetAccountDetails/GetAccountDetailsQueryHandler.cs
+++ b/src/TeamUp.Application/Users/GetAccountDetails/GetAccountDetailsQueryHandler.cs
@@ -5,22 +5,22 @@ using TeamUp.Common;
 using TeamUp.Contracts.Users;
 using TeamUp.Domain.Aggregates.Users;
 
-namespace TeamUp.Application.Users.GetUserDetail;
+namespace TeamUp.Application.Users.GetAccountDetails;
 
-internal sealed class GetUserDetailsQueryHandler : IQueryHandler<GetUserDetailsQuery, Result<UserResponse>>
+internal sealed class GetAccountDetailsQueryHandler : IQueryHandler<GetAccountDetailsQuery, Result<AccountResponse>>
 {
 	private readonly IAppQueryContext _queryContext;
 
-	public GetUserDetailsQueryHandler(IAppQueryContext queryContext)
+	public GetAccountDetailsQueryHandler(IAppQueryContext queryContext)
 	{
 		_queryContext = queryContext;
 	}
 
-	public async Task<Result<UserResponse>> Handle(GetUserDetailsQuery request, CancellationToken ct)
+	public async Task<Result<AccountResponse>> Handle(GetAccountDetailsQuery request, CancellationToken ct)
 	{
 		var user = await _queryContext.Users
 			.Where(user => user.Id == request.UserId)
-			.Select(user => new UserResponse
+			.Select(user => new AccountResponse
 			{
 				Email = user.Email,
 				Name = user.Name,

--- a/src/TeamUp.Application/Users/GetUserDetail/GetUserDetailsQuery.cs
+++ b/src/TeamUp.Application/Users/GetUserDetail/GetUserDetailsQuery.cs
@@ -1,7 +1,0 @@
-﻿using TeamUp.Application.Abstractions;
-using TeamUp.Common;
-using TeamUp.Contracts.Users;
-
-namespace TeamUp.Application.Users.GetUserDetail;
-
-public sealed record GetUserDetailsQuery(UserId UserId) : IQuery<Result<UserResponse>>;

--- a/src/TeamUp.Contracts/Users/AccountResponse.cs
+++ b/src/TeamUp.Contracts/Users/AccountResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace TeamUp.Contracts.Users;
 
-public sealed class UserResponse
+public sealed class AccountResponse
 {
 	public required string Email { get; set; }
 	public required string Name { get; set; }

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/AcceptInvitationTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/AcceptInvitationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
+using TeamUp.Contracts.Invitations;
 using TeamUp.Contracts.Teams;
 
 namespace TeamUp.EndToEndTests.EndpointTests.Invitations;
@@ -7,6 +8,9 @@ namespace TeamUp.EndToEndTests.EndpointTests.Invitations;
 public sealed class AcceptInvitationTests : BaseInvitationTests
 {
 	public AcceptInvitationTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+
+	public static string GetUrl(InvitationId invitationId) => GetUrl(invitationId.Value);
+	public static string GetUrl(Guid invitationId) => $"/api/v1/invitations/{invitationId}/accept";
 
 	[Fact]
 	public async Task AcceptInvitation_ThatIsValid_AsRecipient_Should_RemoveInvitationFromDatabase_And_AddUserAsMemberToTeamInDatabase()
@@ -30,7 +34,7 @@ public sealed class AcceptInvitationTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.PostAsync($"/api/v1/invitations/{invitation.Id.Value}/accept", null);
+		var response = await Client.PostAsync(GetUrl(invitation.Id), null);
 
 		//assert
 		response.Should().Be200Ok();
@@ -75,7 +79,7 @@ public sealed class AcceptInvitationTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.PostAsync($"/api/v1/invitations/{invitation.Id.Value}/accept", null);
+		var response = await Client.PostAsync(GetUrl(invitation.Id), null);
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -101,11 +105,10 @@ public sealed class AcceptInvitationTests : BaseInvitationTests
 			dbContext.Teams.Add(team);
 			return dbContext.SaveChangesAsync();
 		});
-
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.PostAsync($"/api/v1/invitations/{invitationId}/accept", null);
+		var response = await Client.PostAsync(GetUrl(invitationId), null);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -137,7 +140,7 @@ public sealed class AcceptInvitationTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.PostAsync($"/api/v1/invitations/{invitation.Id.Value}/accept", null);
+		var response = await Client.PostAsync(GetUrl(invitation.Id), null);
 
 		//assert
 		response.Should().Be403Forbidden();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/GetTeamInvitationsTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/GetTeamInvitationsTests.cs
@@ -7,6 +7,9 @@ public sealed class GetTeamInvitationsTests : BaseInvitationTests
 {
 	public GetTeamInvitationsTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/invitations/teams/{teamId}";
+
 	[Theory]
 	[InlineData(TeamRole.Coordinator)]
 	[InlineData(TeamRole.Admin)]
@@ -34,7 +37,7 @@ public sealed class GetTeamInvitationsTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+		var response = await Client.GetAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be200Ok();
@@ -64,7 +67,7 @@ public sealed class GetTeamInvitationsTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+		var response = await Client.GetAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -95,7 +98,7 @@ public sealed class GetTeamInvitationsTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/invitations/teams/{team.Id.Value}");
+		var response = await Client.GetAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -120,7 +123,7 @@ public sealed class GetTeamInvitationsTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/invitations/teams/{teamId}");
+		var response = await Client.GetAsync(GetUrl(teamId));
 
 		//assert
 		response.Should().Be404NotFound();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/InviteUserTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Invitations/InviteUserTests.cs
@@ -8,6 +8,8 @@ public sealed class InviteUserTests : BaseInvitationTests
 {
 	public InviteUserTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public const string URL = "/api/v1/invitations";
+
 	[Theory]
 	[InlineData(TeamRole.Coordinator)]
 	[InlineData(TeamRole.Admin)]
@@ -37,7 +39,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be201Created();
@@ -84,7 +86,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be201Created();
@@ -138,7 +140,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -173,7 +175,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -213,7 +215,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be409Conflict();
@@ -249,7 +251,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -280,7 +282,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -305,7 +307,7 @@ public sealed class InviteUserTests : BaseInvitationTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/invitations", request.Request);
+		var response = await Client.PostAsJsonAsync(URL, request.Request);
 
 		//assert
 		response.Should().Be400BadRequest();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeNicknameTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeNicknameTests.cs
@@ -8,6 +8,9 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 {
 	public ChangeNicknameTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}/nickname";
+
 	[Theory]
 	[InlineData(TeamRole.Member)]
 	[InlineData(TeamRole.Coordinator)]
@@ -37,7 +40,7 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/nickname", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be200Ok();
@@ -78,7 +81,7 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/nickname", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -108,7 +111,7 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{teamId}/nickname", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -146,7 +149,7 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/nickname", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be400BadRequest();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeNicknameTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeNicknameTests.cs
@@ -111,7 +111,7 @@ public sealed class ChangeNicknameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), request);
+		var response = await Client.PutAsJsonAsync(GetUrl(teamId), request);
 
 		//assert
 		response.Should().Be404NotFound();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeOwnershipTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/ChangeOwnershipTests.cs
@@ -8,6 +8,9 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 {
 	public ChangeOwnershipTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}/owner";
+
 	[Theory]
 	[InlineData(TeamRole.Member)]
 	[InlineData(TeamRole.Coordinator)]
@@ -33,7 +36,7 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 		var targetMemberId = team.Members.First(member => member.UserId == targetUser.Id).Id;
 
 		//assert
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/owner", targetMemberId.Value);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), targetMemberId.Value);
 
 		//act
 		response.Should().Be200Ok();
@@ -46,11 +49,11 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 				.ToListAsync();
 		});
 
-		var originalOwner = teamMembers.FirstOrDefault(member => member.UserId == owner.Id);
+		var originalOwner = teamMembers.SingleOrDefault(member => member.UserId == owner.Id);
 		originalOwner.ShouldNotBeNull();
 		originalOwner.Role.Should().Be(TeamRole.Admin);
 
-		var newOwner = teamMembers.FirstOrDefault(member => member.UserId == targetUser.Id);
+		var newOwner = teamMembers.SingleOrDefault(member => member.UserId == targetUser.Id);
 		newOwner.ShouldNotBeNull();
 		newOwner.Role.Should().Be(TeamRole.Owner);
 
@@ -92,7 +95,7 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 		var targetMemberId = team.Members.First(member => member.UserId == initiatorUser.Id).Id;
 
 		//assert
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/owner", targetMemberId.Value);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), targetMemberId.Value);
 
 		//act
 		response.Should().Be403Forbidden();
@@ -122,7 +125,7 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 		var targetMemberId = F.Random.Guid();
 
 		//assert
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/owner", targetMemberId);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), targetMemberId);
 
 		//act
 		response.Should().Be404NotFound();
@@ -154,7 +157,7 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 		var targetMemberId = team.Members.First(member => member.UserId == targetUser.Id).Id.Value;
 
 		//assert
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/owner", targetMemberId);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id), targetMemberId);
 
 		//act
 		response.Should().Be403Forbidden();
@@ -181,7 +184,7 @@ public sealed class ChangeOwnershipTests : BaseTeamTests
 		var targetMemberId = F.Random.Guid();
 
 		//assert
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{teamId}/owner", targetMemberId);
+		var response = await Client.PutAsJsonAsync(GetUrl(teamId), targetMemberId);
 
 		//act
 		response.Should().Be404NotFound();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/CreateEventTypeTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/CreateEventTypeTests.cs
@@ -6,6 +6,9 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 {
 	public CreateEventTypeTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}/event-types";
+
 	[Theory]
 	[InlineData(TeamRole.Coordinator)]
 	[InlineData(TeamRole.Admin)]
@@ -30,7 +33,7 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 		var request = TeamGenerator.ValidUpsertEventTypeRequest.Generate();
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/teams/{team.Id.Value}/event-types", request);
+		var response = await Client.PostAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be201Created();
@@ -72,7 +75,7 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 		var request = TeamGenerator.ValidUpsertEventTypeRequest.Generate();
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/teams/{team.Id.Value}/event-types", request);
+		var response = await Client.PostAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -103,7 +106,7 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 		var request = TeamGenerator.ValidUpsertEventTypeRequest.Generate();
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/teams/{team.Id.Value}/event-types", request);
+		var response = await Client.PostAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -130,7 +133,7 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 		var request = TeamGenerator.ValidUpsertEventTypeRequest.Generate();
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/teams/{teamId}/event-types", request);
+		var response = await Client.PostAsJsonAsync(GetUrl(teamId), request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -159,7 +162,7 @@ public sealed class CreateEventTypeTests : BaseTeamTests
 		Authenticate(owner);
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/teams/{team.Id.Value}/event-types", request.Request);
+		var response = await Client.PostAsJsonAsync(GetUrl(team.Id), request.Request);
 
 		//assert
 		response.Should().Be400BadRequest();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/CreateTeamTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/CreateTeamTests.cs
@@ -8,6 +8,8 @@ public sealed class CreateTeamTests : BaseTeamTests
 {
 	public CreateTeamTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public const string URL = "/api/v1/teams";
+
 	[Fact]
 	public async Task CreateTeam_Should_CreateNewTeamInDatabase_WithOneTeamOwner()
 	{
@@ -27,7 +29,7 @@ public sealed class CreateTeamTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/teams", createTeamRequest);
+		var response = await Client.PostAsJsonAsync(URL, createTeamRequest);
 
 		//assert
 		response.Should().Be201Created();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/DeleteTeamTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/DeleteTeamTests.cs
@@ -8,6 +8,9 @@ public sealed class DeleteTeamTests : BaseTeamTests
 {
 	public DeleteTeamTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}";
+
 	[Fact]
 	public async Task DeleteTeam_AsOwner_Should_DeleteTeamInDatabase()
 	{
@@ -27,7 +30,7 @@ public sealed class DeleteTeamTests : BaseTeamTests
 		Authenticate(owner);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be200Ok();
@@ -74,7 +77,7 @@ public sealed class DeleteTeamTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -95,11 +98,10 @@ public sealed class DeleteTeamTests : BaseTeamTests
 			dbContext.Users.Add(user);
 			return dbContext.SaveChangesAsync();
 		});
-
 		Authenticate(user);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{teamId}");
+		var response = await Client.DeleteAsync(GetUrl(teamId));
 
 		//assert
 		response.Should().Be404NotFound();
@@ -128,7 +130,7 @@ public sealed class DeleteTeamTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be403Forbidden();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/GetTeamTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/GetTeamTests.cs
@@ -6,6 +6,9 @@ public sealed class GetTeamTests : BaseTeamTests
 {
 	public GetTeamTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}";
+
 	[Fact]
 	public async Task GetTeam_ThatDoesNotExist_Should_ResultInNotFound()
 	{
@@ -18,11 +21,10 @@ public sealed class GetTeamTests : BaseTeamTests
 			dbContext.Users.Add(user);
 			return dbContext.SaveChangesAsync();
 		});
-
 		Authenticate(user);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/teams/{teamId}");
+		var response = await Client.GetAsync(GetUrl(teamId));
 
 		//assert
 		response.Should().Be404NotFound();
@@ -54,7 +56,7 @@ public sealed class GetTeamTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/teams/{team.Id.Value}");
+		var response = await Client.GetAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be200Ok();
@@ -89,7 +91,7 @@ public sealed class GetTeamTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.GetAsync($"/api/v1/teams/{team.Id.Value}");
+		var response = await Client.GetAsync(GetUrl(team.Id));
 
 		//assert
 		response.Should().Be403Forbidden();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/RemoveTeamMemberTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/RemoveTeamMemberTests.cs
@@ -7,7 +7,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 	public RemoveTeamMemberTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
 	public static string GetUrl(TeamId teamId, TeamMemberId memberId) => GetUrl(teamId.Value, memberId.Value);
-	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/{memberId}";
+	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/members/{memberId}";
 
 	[Theory]
 	[InlineData(TeamRole.Admin, TeamRole.Member)]

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/RemoveTeamMemberTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/RemoveTeamMemberTests.cs
@@ -6,6 +6,9 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 {
 	public RemoveTeamMemberTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId, TeamMemberId memberId) => GetUrl(teamId.Value, memberId.Value);
+	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/{memberId}";
+
 	[Theory]
 	[InlineData(TeamRole.Admin, TeamRole.Member)]
 	[InlineData(TeamRole.Admin, TeamRole.Coordinator)]
@@ -34,7 +37,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be200Ok();
@@ -74,7 +77,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be200Ok();
@@ -115,7 +118,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -145,7 +148,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(owner);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -176,7 +179,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(owner);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -206,7 +209,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(owner);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id.Value, targetMemberId));
 
 		//assert
 		response.Should().Be404NotFound();
@@ -229,11 +232,10 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 			dbContext.Users.Add(user);
 			return dbContext.SaveChangesAsync();
 		});
-
 		Authenticate(user);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{teamId}/{targetMemberId}");
+		var response = await Client.DeleteAsync(GetUrl(teamId, targetMemberId));
 
 		//assert
 		response.Should().Be404NotFound();
@@ -264,7 +266,7 @@ public sealed class RemoveTeamMemberTests : BaseTeamTests
 		Authenticate(initiatorUser);
 
 		//act
-		var response = await Client.DeleteAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}");
+		var response = await Client.DeleteAsync(GetUrl(team.Id, targetMemberId));
 
 		//assert
 		response.Should().Be403Forbidden();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamMemberRoleTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamMemberRoleTests.cs
@@ -8,6 +8,10 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 {
 	public UpdateTeamMemberRoleTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId, TeamMemberId memberId) => GetUrl(teamId.Value, memberId.Value);
+	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/{memberId}/role";
+
+
 	[Theory]
 	[InlineData(TeamRole.Admin, TeamRole.Member, TeamRole.Admin)]
 	[InlineData(TeamRole.Admin, TeamRole.Member, TeamRole.Coordinator)]
@@ -46,7 +50,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id, targetMemberId), request);
 
 		//assert
 		response.Should().Be200Ok();
@@ -107,7 +111,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id, targetMemberId), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -147,7 +151,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id, targetMemberId), request);
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -186,7 +190,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id, targetMemberId), request);
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -220,7 +224,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id.Value, targetMemberId), request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -251,7 +255,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{teamId}/{targetMemberId}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(teamId, targetMemberId), request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -286,7 +290,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PutAsJsonAsync($"/api/v1/teams/{team.Id.Value}/{targetMemberId.Value}/role", request);
+		var response = await Client.PutAsJsonAsync(GetUrl(team.Id, targetMemberId), request);
 
 		//assert
 		response.Should().Be403Forbidden();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamMemberRoleTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamMemberRoleTests.cs
@@ -9,7 +9,7 @@ public sealed class UpdateTeamMemberRoleTests : BaseTeamTests
 	public UpdateTeamMemberRoleTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
 	public static string GetUrl(TeamId teamId, TeamMemberId memberId) => GetUrl(teamId.Value, memberId.Value);
-	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/{memberId}/role";
+	public static string GetUrl(Guid teamId, Guid memberId) => $"/api/v1/teams/{teamId}/members/{memberId}/role";
 
 
 	[Theory]

--- a/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamNameTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/Teams/UpdateTeamNameTests.cs
@@ -6,6 +6,9 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 {
 	public UpdateTeamNameTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(TeamId teamId) => GetUrl(teamId.Value);
+	public static string GetUrl(Guid teamId) => $"/api/v1/teams/{teamId}";
+
 	[Fact]
 	public async Task UpdateTeamName_AsOwner_Should_UpdateTeamNameInDatabase()
 	{
@@ -30,7 +33,7 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PatchAsJsonAsync($"/api/v1/teams/{team.Id.Value}", request);
+		var response = await Client.PatchAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be200Ok();
@@ -68,7 +71,7 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PatchAsJsonAsync($"/api/v1/teams/{team.Id.Value}", request);
+		var response = await Client.PatchAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -98,7 +101,7 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PatchAsJsonAsync($"/api/v1/teams/{teamId}", request);
+		var response = await Client.PatchAsJsonAsync(GetUrl(teamId), request);
 
 		//assert
 		response.Should().Be404NotFound();
@@ -132,7 +135,7 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PatchAsJsonAsync($"/api/v1/teams/{team.Id.Value}", request);
+		var response = await Client.PatchAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be403Forbidden();
@@ -168,7 +171,7 @@ public sealed class UpdateTeamNameTests : BaseTeamTests
 		};
 
 		//act
-		var response = await Client.PatchAsJsonAsync($"/api/v1/teams/{team.Id.Value}", request);
+		var response = await Client.PatchAsJsonAsync(GetUrl(team.Id), request);
 
 		//assert
 		response.Should().Be400BadRequest();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/ActivateAccountTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/ActivateAccountTests.cs
@@ -6,6 +6,9 @@ public sealed class ActivateAccountTests : BaseUserAccessTests
 {
 	public ActivateAccountTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public static string GetUrl(UserId userId) => GetUrl(userId.Value);
+	public static string GetUrl(Guid userId) => $"/api/v1/users/{userId}/activate";
+
 	[Fact]
 	public async Task ActivateAccount_Should_SetUserStatusAsActivatedInDatabase()
 	{
@@ -19,7 +22,7 @@ public sealed class ActivateAccountTests : BaseUserAccessTests
 		});
 
 		//act
-		var response = await Client.PostAsJsonAsync($"/api/v1/users/{user.Id.Value}/activate", EmptyObject);
+		var response = await Client.PostAsJsonAsync(GetUrl(user.Id), EmptyObject);
 
 		//assert
 		response.Should().Be200Ok();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/GetMyAccountDetailsTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/GetMyAccountDetailsTests.cs
@@ -2,9 +2,9 @@
 
 namespace TeamUp.EndToEndTests.EndpointTests.UserAccess;
 
-public sealed class GetUserDetailsTests : BaseUserAccessTests
+public sealed class GetMyAccountDetailsTests : BaseUserAccessTests
 {
-	public GetUserDetailsTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
+	public GetMyAccountDetailsTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
 	public const string URL = "/api/v1/users";
 
@@ -39,7 +39,7 @@ public sealed class GetUserDetailsTests : BaseUserAccessTests
 		//assert
 		response.Should().Be200Ok();
 
-		var userResponse = await response.ReadFromJsonAsync<UserResponse>();
+		var userResponse = await response.ReadFromJsonAsync<AccountResponse>();
 		user.Should().BeEquivalentTo(userResponse, o => o.ExcludingMissingMembers());
 	}
 }

--- a/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/GetUserDetailsTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/GetUserDetailsTests.cs
@@ -6,12 +6,14 @@ public sealed class GetUserDetailsTests : BaseUserAccessTests
 {
 	public GetUserDetailsTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public const string URL = "/api/v1/users";
+
 	[Fact]
 	public async Task GetMyProfile_WhenUnauthenticated_Should_ResultInUnauthorized()
 	{
 		//arrange
 		//act
-		var response = await Client.GetAsync("/api/v1/users");
+		var response = await Client.GetAsync(URL);
 
 		//assert
 		response.Should().Be401Unauthorized();
@@ -32,7 +34,7 @@ public sealed class GetUserDetailsTests : BaseUserAccessTests
 		Authenticate(user);
 
 		//act
-		var response = await Client.GetAsync("/api/v1/users");
+		var response = await Client.GetAsync(URL);
 
 		//assert
 		response.Should().Be200Ok();

--- a/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/LoginTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/LoginTests.cs
@@ -10,6 +10,8 @@ public sealed class LoginTests : BaseUserAccessTests
 {
 	public LoginTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public const string URL = "/api/v1/users/login";
+
 	[Fact]
 	public async Task Login_AsActivatedUser_Should_GenerateValidJwtToken()
 	{
@@ -32,7 +34,7 @@ public sealed class LoginTests : BaseUserAccessTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/login", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be200Ok();
@@ -76,7 +78,7 @@ public sealed class LoginTests : BaseUserAccessTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/login", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be401Unauthorized();
@@ -97,7 +99,7 @@ public sealed class LoginTests : BaseUserAccessTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/login", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be401Unauthorized();
@@ -128,7 +130,7 @@ public sealed class LoginTests : BaseUserAccessTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/login", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be401Unauthorized();
@@ -136,5 +138,4 @@ public sealed class LoginTests : BaseUserAccessTests
 		var problemDetails = await response.ReadProblemDetailsAsync();
 		problemDetails.ShouldContainError(AuthenticationErrors.InvalidCredentials);
 	}
-
 }

--- a/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/RegisterUserTests.cs
+++ b/tests/TeamUp.EndToEndTests/EndpointTests/UserAccess/RegisterUserTests.cs
@@ -6,6 +6,8 @@ public sealed class RegisterUserTests : BaseUserAccessTests
 {
 	public RegisterUserTests(TeamApiWebApplicationFactory appFactory) : base(appFactory) { }
 
+	public const string URL = "/api/v1/users/register";
+
 	[Fact]
 	public async Task RegisterUser_Should_CreateNewUserInDatabase_And_SendActivationEmail()
 	{
@@ -13,7 +15,7 @@ public sealed class RegisterUserTests : BaseUserAccessTests
 		var request = UserGenerator.ValidRegisterUserRequest.Generate();
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/register", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be201Created();
@@ -52,7 +54,7 @@ public sealed class RegisterUserTests : BaseUserAccessTests
 		};
 
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/register", request);
+		var response = await Client.PostAsJsonAsync(URL, request);
 
 		//assert
 		response.Should().Be409Conflict();
@@ -67,7 +69,7 @@ public sealed class RegisterUserTests : BaseUserAccessTests
 	{
 		//arrange
 		//act
-		var response = await Client.PostAsJsonAsync("/api/v1/users/register", request.Request);
+		var response = await Client.PostAsJsonAsync(URL, request.Request);
 
 		//assert
 		response.Should().Be400BadRequest();
@@ -75,5 +77,4 @@ public sealed class RegisterUserTests : BaseUserAccessTests
 		var problemDetails = await response.ReadValidationProblemDetailsAsync();
 		problemDetails.ShouldContainValidationErrorFor(request.InvalidProperty);
 	}
-
 }


### PR DESCRIPTION
- refactored endpoint tests to use URL/GetUrl for retrieving target endpoint url
- fixed endpoints to use ProduceProblem for error codes, fixed endpoints to have consistently ordered options
- added members section for accessing team members endpoints
- renamed user details contract, endpoint, command, command handler and tests to AccountDetails
- renamed logged in user to current user