### PR TITLE
Fixed Delete Team Endpoint Tests

### DIFF
--- a/tests/TeamUp.Tests.Common/DataGenerators/TeamGeneratorExtensions.cs
+++ b/tests/TeamUp.Tests.Common/DataGenerators/TeamGeneratorExtensions.cs
@@ -43,12 +43,12 @@ public static class TeamGeneratorExtensions
 
 		return teamGenerator
 			.RuleFor(TeamGenerators.TEAM_MEMBERS_FIELD, (f, t) => f
-				.Make(count, index => f.PickRandom(pot)
+				.Make(count, index => f.PopRandom(new List<User>(pot))
 					.Map(user => TeamGenerators.TeamMember
 						.RuleForBackingField(tm => tm.TeamId, t.Id)
 						.RuleForBackingField(tm => tm.UserId, user.Id)
 						.RuleFor(tm => tm.Nickname, user.Name)
-						.RuleFor(tm => tm.Role, index == 0 ? TeamRole.Owner : TeamRole.Member)
+						.RuleFor(tm => tm.Role, index == 1 ? TeamRole.Owner : TeamRole.Member)
 						.Generate()))
 				.ToHashSet()
 				.ToList());

--- a/tests/TeamUp.Tests.Common/Extensions/FakerExtensions.cs
+++ b/tests/TeamUp.Tests.Common/Extensions/FakerExtensions.cs
@@ -13,6 +13,13 @@ public static class FakerExtensions
 		return list[index];
 	}
 
+	public static T PopRandom<T>(this Faker faker, List<T> list) where T : class
+	{
+		var elem = faker.PickRandom(list);
+		list.Remove(elem);
+		return elem;
+	}
+
 	public static Faker<T> UsePrivateConstructor<T>(this Faker<T> faker) where T : class
 		=> faker.CustomInstantiator(f => (Activator.CreateInstance(typeof(T), nonPublic: true) as T)!);
 

--- a/tests/TeamUp.Tests.EndToEnd/AppFactory.cs
+++ b/tests/TeamUp.Tests.EndToEnd/AppFactory.cs
@@ -34,7 +34,7 @@ public sealed class AppFactory(string connectionString) : WebApplicationFactory<
 				options.UseNpgsql(connectionString);
 				options.ConfigureWarnings(warning =>
 				{
-					warning.Throw(RelationalEventId.MultipleCollectionIncludeWarning);
+					warning.Log(RelationalEventId.MultipleCollectionIncludeWarning);
 				});
 			});
 

--- a/tests/TeamUp.Tests.EndToEnd/EndpointTests/Teams/TeamTests.DeleteTeam.cs
+++ b/tests/TeamUp.Tests.EndToEnd/EndpointTests/Teams/TeamTests.DeleteTeam.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-using EventResponse = TeamUp.Domain.Aggregates.Events.EventResponse;
-
 namespace TeamUp.Tests.EndToEnd.EndpointTests.Teams;
 
 public sealed class DeleteTeamTests(AppFixture app) : TeamTests(app)
@@ -31,6 +29,8 @@ public sealed class DeleteTeamTests(AppFixture app) : TeamTests(app)
 
 		var targetTeamIndex = F.Random.Int(0, teams.Count - 1);
 		var targetTeam = teams[targetTeamIndex];
+		var teamOwner = targetTeam.Members.Single(member => member.Role.IsOwner());
+		var initiatorUser = users.Single(user => user.Id == teamOwner.UserId);
 
 		await UseDbContextAsync(dbContext =>
 		{
@@ -39,9 +39,6 @@ public sealed class DeleteTeamTests(AppFixture app) : TeamTests(app)
 			dbContext.Events.AddRange(events);
 			return dbContext.SaveChangesAsync();
 		});
-
-		var owner = targetTeam.Members.Single(member => member.Role.IsOwner());
-		var initiatorUser = users.Single(user => user.Id == owner.UserId);
 
 		Authenticate(initiatorUser);
 


### PR DESCRIPTION
* fixed to correctly create data and test existence of data after removing team from database
* fixed correct creating of owner in WithRandomMembers method for testing data
* fixed default behavior of MultipleCollectionIncludeWarning for endpoint tests